### PR TITLE
Add instructions for yarn create with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ by adding  `--example <example-name>` to your command.**
 create-razzle-app --example with-preact my-app
 ```
 
+or with `yarn create`
+
+```bash
+yarn create razzle-app my-app -- --example with-preact
+```
+
+_(The `--` is needed for yarn to ignore options meant for `create-razzle-app`)_
+
 It will create a directory called my-app inside the current folder.  
 Inside that directory, it will generate the initial project structure and install the transitive dependencies. 
 


### PR DESCRIPTION
It may be worth opening an issue with `yarn` to see if they want `yarn create --whatever --flags--here` to be forwarded to the sub-command, since the ideal is:

```shell
yarn create razzle-app my-app --example with-preact
```