### PR TITLE
Use npx instead of global install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yarn create razzle-app my-app
 by adding  `--example <example-name>` to your command.**
 
 ```bash
-create-razzle-app --example with-preact my-app
+npx create-razzle-app --example with-preact my-app
 ```
 
 or with `yarn create`

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Razzle comes with the "battery-pack included" and is part of a complete JavaScri
 ## Quick Start
 
 ```bash
-$ npm i -g create-razzle-app
-
-create-razzle-app my-app
+$ npx create-razzle-app my-app
 cd my-app
 npm start
 ```
@@ -73,21 +71,12 @@ When you’re ready to deploy to production, create a minified bundle with `npm 
 
 ## Getting Started
 
-### Installation
-If you have the latest version of Yarn, you can skip this. Otherwise:
-
-Install Razzle globally:
-
-```
-npm i -g create-razzle-app
-```
-
 ### Creating an app
 
 To create an app, run:
 
 ```bash
-create-razzle-app my-app
+npx create-razzle-app my-app
 ```
 
 or with `yarn create` (new!):

--- a/packages/create-razzle-app/README.md
+++ b/packages/create-razzle-app/README.md
@@ -3,8 +3,7 @@
 Create UNIVERSAL React, Preact, and Inferno apps in one command.
 
 ```
-npm i -g create-razzle-app
-create-razzle-app my-proj
+npx create-razzle-app my-proj
 cd my-proj
 npm start
 ```
@@ -20,7 +19,7 @@ yarn start
 You can also initialize a project from one of the examples.
 
 ```
-create-razzle-app --example with-preact my-preact-app
+npx create-razzle-app --example with-preact my-preact-app
 cd my-preact-app
 npm start
 ```

--- a/packages/razzle/README.md
+++ b/packages/razzle/README.md
@@ -49,9 +49,7 @@ Razzle comes with the "battery-pack included" and is part of a complete JavaScri
 ## Quick Start
 
 ```bash
-$ npm i -g create-razzle-app
-
-create-razzle-app my-app
+$ npx create-razzle-app my-app
 cd my-app
 npm start
 ```
@@ -73,21 +71,12 @@ When you’re ready to deploy to production, create a minified bundle with `npm 
 
 ## Getting Started
 
-### Installation
-If you have the latest version of Yarn, you can skip this. Otherwise:
-
-Install Razzle globally:
-
-```
-npm i -g create-razzle-app
-```
-
 ### Creating an app
 
 To create an app, run:
 
 ```bash
-create-razzle-app my-app
+npx create-razzle-app my-app
 ```
 
 or with `yarn create` (new!):
@@ -100,7 +89,7 @@ yarn create razzle-app my-app
 by adding  `--example <example-name>` to your command.**
 
 ```bash
-create-razzle-app --example with-preact my-app
+npx create-razzle-app --example with-preact my-app
 ```
 
 or with `yarn create`


### PR DESCRIPTION
`npx` has been introduced in npm 5.2, and I'm guessing it's npm's answer to `yarn create`. ([read the full intro here](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b))
It's perfect for tools like `create-razzle-app` which you only run once in a while and would absolutely prefer to be as up to date as possible.
It is fairly new so it might not exist on people's machines in a lot of cases, but then again, so is `yarn create` and it appears to be the suggested way right now to run create-razzle-app with yarn.
But I'm open to adding a warning perhaps telling people to update their npm to 5.2>