### PR TITLE
Fix node path usage

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -10,7 +10,8 @@ const FriendlyErrorsPlugin = require('razzle-dev-utils/FriendlyErrorsPlugin');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const paths = require('./paths');
-const getEnv = require('./env');
+const getClientEnv = require('./env').getClientEnv;
+const nodePath = require('./env').nodePath;
 
 // This is the Webpack configuration factory. It's the juice!
 module.exports = (
@@ -40,7 +41,7 @@ module.exports = (
   const IS_DEV = env === 'dev';
   process.env.NODE_ENV = IS_PROD ? 'production' : 'development';
 
-  const dotenv = getEnv(target, { clearConsole, host, port });
+  const dotenv = getClientEnv(target, { clearConsole, host, port });
 
   const devServerPort = parseInt(dotenv.raw.PORT, 10) + 1;
   // This is our base webpack config.
@@ -57,7 +58,7 @@ module.exports = (
       // modules: ['node_modules', paths.appNodeModules].concat(paths.nodePaths),
       modules: ['node_modules', paths.appNodeModules].concat(
         // It is guaranteed to exist because we tweak it in `env.js`
-        process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
+        nodePath.split(path.delimiter).filter(Boolean)
       ),
       extensions: ['.js', '.json', '.jsx'],
       alias: {

--- a/packages/razzle/config/env.js
+++ b/packages/razzle/config/env.js
@@ -43,7 +43,7 @@ dotenvFiles.forEach(dotenvFile => {
 // https://github.com/facebookincubator/create-react-app/issues/1023#issuecomment-265344421
 // We also resolve them to make sure all tools using them work consistently.
 const appDirectory = fs.realpathSync(process.cwd());
-process.env.NODE_PATH = (process.env.NODE_PATH || '')
+const nodePath = (process.env.NODE_PATH || '')
   .split(path.delimiter)
   .filter(folder => folder && !path.isAbsolute(folder))
   .map(folder => path.resolve(appDirectory, folder))
@@ -86,4 +86,7 @@ function getClientEnvironment(target, options) {
   return { raw, stringified };
 }
 
-module.exports = getClientEnvironment;
+module.exports = {
+  getClientEnv: getClientEnvironment,
+  nodePath: nodePath,
+};


### PR DESCRIPTION
Hey Jared,

On my exploration through razzle I stumbled over [this compatibility issue](https://github.com/jaredpalmer/razzle/issues/287). The culprit is a race-condition which I fixed by replacing the use of the `process.env.NODE_PATH`-global with an exported variable. Not sure why it only happens on windows, must have something to do with how Node handles imports/exports and envs in that OS.

It was already working like this:
```js
// packages/razzle/config/createConfig.js
// ...
const getEnv = require('./env');

const nodePath = process.env.NODE_PATH;

module.exports = (
// ...
      modules: ['node_modules', paths.appNodeModules].concat(
        nodePath.split(path.delimiter).filter(Boolean)
      )
// ...
````

but I thought that having a dangling variable there would be confusing, therefore I opted to reduce the reliance on the relevant global entirely.

Love the concept of razzle btw, great stuff 👍 