### PR TITLE
Fix #302: Don't watch assets.json

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -245,6 +245,8 @@ module.exports = (
         new webpack.NoEmitOnErrorsPlugin(),
         // Automatically start the server when we are done compiling
         new StartServerPlugin('server.js'),
+        // Ignore assets.json to avoid infinite recompile bug
+        new webpack.WatchIgnorePlugin([paths.appManifest]),
       ];
     }
   }


### PR DESCRIPTION
The `assets.json` trigger watch several times, so I just ignored it in watch mode.