### PR TITLE
Allowing `setupFiles` for Jest configuration

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -44,6 +44,7 @@ module.exports = (resolve, rootDir) => {
     'moduleNameMapper',
     'modulePaths',
     'snapshotSerializers',
+    'setupFiles',
     'testMatch',
     'testResultsProcessor',
     'transform',


### PR DESCRIPTION
With Enzyme 3 (in order to test a React 16 app) an [adapter](http://airbnb.io/enzyme/docs/installation/index.html#working-with-react-16) has to be configured.

In addition, [React 16 depends on `requestAnimationFrame`](http://fb.me/react-polyfills).

The easy way to fix these issues is using the `setupFiles` configuration (`package.json` example): 

```json
{
  ...
  "jest": {
    "setupFiles": [
      "raf/polyfill",
      "<rootDir>/src/test/setup.js"
    ]
  },
  ...
}
```

```
// src/test/setup.js
import { configure } from 'enzyme';
import Adapter from 'enzyme-adapter-react-16';

configure({ adapter: new Adapter() });
```

But, razzle doesn't allow this configuration parameter. This PR allows the use of that keyword.