### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ Razzle comes with most of ES6 stuff you need. However, if you want to add your o
   "presets": [
     "razzle/babel", // NEEDED
     "stage-0"
+   ],
+   "plugins": [
+     // additional plugins
    ]
 }
 ```
-A word of advice: `.babelrc` file will replace the internal razzle's babelrc template. You must include very minimum the default razzle/babel presets.
+
+A word of advice: the `.babelrc` file will replace the internal razzle babelrc template. You must include at the very minimum the default razzle/babel preset.
 
 ### Extending Webpack
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To debug the node server, you can use `razzle start --inspect`. This will start 
 
 Razzle comes with most of ES6 stuff you need. However, if you want to add your own babel transformations, just add a `.babelrc` file to the root of your project. 
 
-```json
+```js
 {
   "presets": [
     "razzle/babel", // NEEDED

--- a/README.md
+++ b/README.md
@@ -83,18 +83,19 @@ To debug the node server, you can use `razzle start --inspect`. This will start 
 
 ## Customization
 
-### Extending Babel Config
+### Customizing Babel Config
 
 Razzle comes with most of ES6 stuff you need. However, if you want to add your own babel transformations, just add a `.babelrc` file to the root of your project. 
 
 ```json
 {
   "presets": [
-    "razzle/babel",
+    "razzle/babel", // NEEDED
     "stage-0"
    ]
 }
 ```
+A word of advice: `.babelrc` file will replace the internal razzle's babelrc template. You must include very minimum the default razzle/babel presets.
 
 ### Extending Webpack
 


### PR DESCRIPTION
This is related to the issue #368 

Warn users that razzle/babel presets must be present in customized .babelrc file.

Also to change the word 'Extending' to 'Customizing'.