### PR TITLE
Fix creating multiple server chunks

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -259,6 +259,10 @@ module.exports = (
       new webpack.NamedModulesPlugin(),
       // We define environment variables that can be accessed globally in our
       new webpack.DefinePlugin(dotenv.stringified),
+      // Prevent creating multiple chunks for the server
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
     ];
 
     config.entry = [paths.appServerIndexJs];


### PR DESCRIPTION
When adding Code Splitting with dynamic imports, multiple bundles will be created for the client, but unfortunately for the server too:
![image](https://user-images.githubusercontent.com/5080854/31867219-98a8b578-b78b-11e7-8c3c-d126e7b06aeb.png)

This PR [disables code splitting](https://medium.com/@glennreyes/how-to-disable-code-splitting-in-webpack-1c0b1754a3c5) by limiting the server chunks to one single file in the node instance:
![image](https://user-images.githubusercontent.com/5080854/31867251-24a80902-b78c-11e7-94ec-534f81b64b67.png)

See sample [here](https://github.com/glennreyes/razzle-sample)