### PR TITLE
Make React Razzle project easily deployable

### DIFF
--- a/packages/create-razzle-app/templates/default/package.json
+++ b/packages/create-razzle-app/templates/default/package.json
@@ -6,7 +6,9 @@
     "start": "razzle start",
     "build": "razzle build",
     "test": "razzle test --env=jsdom",
-    "start:prod": "NODE_ENV=production node build/server.js"
+    "start:prod": "NODE_ENV=production node build/server.js",
+    "now-start": "npm run start:prod",
+    "deploy": "now -e NODE_ENV=production"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
I noticed that Razzle seems to be missing a deployment story. Deploying with [now](https://github.com/zeit/now-cli) by default doesn't work because the default `start` command is for dev command only.

So I added a couple of lines to `package.json` and now (sic) it works. 

```
"now-start": "npm run start:prod",
"deploy": "now -e NODE_ENV=production"
```

I think it could be useful seeing the project live on a url from the get-go. Here is what a sample deployment looks like: https://my-razzle-app-sutwyzgqpe.now.sh/