### PR TITLE
Use valid `http-equiv` attribute in meta tags

### DIFF
--- a/examples/basic/src/server.js
+++ b/examples/basic/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-custom-babel-config/src/server.js
+++ b/examples/with-custom-babel-config/src/server.js
@@ -26,7 +26,7 @@ server
         `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-custom-environment-variables/src/server.js
+++ b/examples/with-custom-environment-variables/src/server.js
@@ -17,7 +17,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-custom-webpack-config/src/server.js
+++ b/examples/with-custom-webpack-config/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-elm/src/server.js
+++ b/examples/with-elm/src/server.js
@@ -19,7 +19,7 @@ server
       `<!doctype html>
       <html lang="">
         <head>
-            <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
             <meta charSet='utf-8' />
             <title>Welcome to Razzle</title>
             <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-inferno/src/server.js
+++ b/examples/with-inferno/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-jest-snapshots/src/server.js
+++ b/examples/with-jest-snapshots/src/server.js
@@ -26,7 +26,7 @@ server
         `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-jsxstyle/README.md
+++ b/examples/with-jsxstyle/README.md
@@ -47,7 +47,7 @@ server
         `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-jsxstyle/src/server.js
+++ b/examples/with-jsxstyle/src/server.js
@@ -32,7 +32,7 @@ server
         `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-material-ui/src/server.js
+++ b/examples/with-material-ui/src/server.js
@@ -32,7 +32,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-preact/src/server.js
+++ b/examples/with-preact/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-rax/src/server.js
+++ b/examples/with-rax/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-react-loadable/src/server.js
+++ b/examples/with-react-loadable/src/server.js
@@ -34,7 +34,7 @@ server
         `<!doctype html>
 <html lang="">
   <head>
-    <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charSet='utf-8' />
     <title>Welcome to Razzle</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-reason-react/README.md
+++ b/examples/with-reason-react/README.md
@@ -147,7 +147,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle Reason React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-reason-react/src/server.js
+++ b/examples/with-reason-react/src/server.js
@@ -19,7 +19,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle Reason React</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-redux/src/server/index.js
+++ b/examples/with-redux/src/server/index.js
@@ -40,7 +40,7 @@ server
       res.send(`<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Razzle Redux Example</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-styled-components/src/server.js
+++ b/examples/with-styled-components/src/server.js
@@ -24,7 +24,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-typescript/src/server.tsx
+++ b/examples/with-typescript/src/server.tsx
@@ -17,7 +17,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Razzle TypeScript</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-vendor-bundle/README.md
+++ b/examples/with-vendor-bundle/README.md
@@ -90,7 +90,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/with-vendor-bundle/src/server.js
+++ b/examples/with-vendor-bundle/src/server.js
@@ -16,7 +16,7 @@ server
       `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/packages/create-razzle-app/templates/default/src/server.js
+++ b/packages/create-razzle-app/templates/default/src/server.js
@@ -25,7 +25,7 @@ server
         `<!doctype html>
     <html lang="">
     <head>
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta charSet='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
According to the [W3C Validator](https://validator.w3.org), the `httpEquiv` attribute should be `http-equiv`.

This pull request updates the *server.js* template and all examples.

<img width="994" alt="W3C Validator Screenshot" src="https://user-images.githubusercontent.com/50329/33148766-afcd281e-cf92-11e7-9aac-4c829fc1cd19.png">

--

Thanks @jaredpalmer for such an awesome project!