### PR TITLE
Check if ports in use in start script (#397)

### DIFF
--- a/packages/razzle-dev-utils/setPorts.js
+++ b/packages/razzle-dev-utils/setPorts.js
@@ -1,0 +1,12 @@
+const { choosePort } = require('react-dev-utils/WebpackDevServerUtils');
+
+// Checks if PORT and PORT_DEV are available and suggests alternatives if not
+module.exports = async () => {
+  const port = await choosePort(process.env.HOST, process.env.PORT || 3000);
+  const portDev = await choosePort(
+    process.env.HOST,
+    process.env.PORT_DEV || 3001
+  );
+  process.env.PORT = port;
+  process.env.PORT_DEV = portDev;
+};

--- a/packages/razzle/README.md
+++ b/packages/razzle/README.md
@@ -141,6 +141,7 @@ Last but not least, if you find yourself needing a more customized setup, Razzle
 - `process.env.REACT_DEV_BUNDLE_PATH`: Relative path to where React will be bundled during development. Unless you are modifying the output path of your webpack config, you can safely ignore this. This path is used by `react-error-overlay` and webpack to power up the fancy runtime error iframe. For example, if you are using common chunks and an extra entry to create a vendor bundle with stuff like react, react-dom, react-router, etc. called `vendor.js`, and you've changed webpack's output to `[name].js` in development, you'd want to set this environment variable to `/static/js/vendor.js`. If you do not make this change, nothing bad will happen, you will simply not get the cool error overlay when there are runtime errors. You'll just see them in the console. Note: This does not impact production bundling.
 - `process.env.VERBOSE`: default is false, setting this to true will not clear the console when you make edits in development (useful for debugging).
 - `process.env.PORT`: default is `3000`, unless changed
+- `process.env.PORT_DEV`: default is `3001`, unless changed
 - `process.env.HOST`: default is `0.0.0.0`
 - `process.env.NODE_ENV`: `'development'` or `'production'`
 - `process.env.BUILD_TARGET`: either `'client'` or `'server'`

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -10,6 +10,7 @@ const devServer = require('webpack-dev-server');
 const printErrors = require('razzle-dev-utils/printErrors');
 const clearConsole = require('react-dev-utils/clearConsole');
 const logger = require('razzle-dev-utils/logger');
+const setPorts = require('razzle-dev-utils/setPorts');
 
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
@@ -17,74 +18,76 @@ if (process.argv.includes('--inspect')) {
   process.env.INSPECT_ENABLED = true;
 }
 
-// Optimistically, we make the console look exactly like the output of our
-// FriendlyErrorsPlugin during compilation, so the user has immediate feedback.
-// clearConsole();
-logger.start('Compiling...');
-let razzle = {};
+function main() {
+  // Optimistically, we make the console look exactly like the output of our
+  // FriendlyErrorsPlugin during compilation, so the user has immediate feedback.
+  // clearConsole();
+  logger.start('Compiling...');
+  let razzle = {};
 
-// Check for razzle.config.js file
-if (fs.existsSync(paths.appRazzleConfig)) {
-  try {
-    razzle = require(paths.appRazzleConfig);
-  } catch (e) {
-    clearConsole();
-    logger.error('Invalid razzle.config.js file.', e);
-    process.exit(1);
-  }
-}
-
-// Delete assets.json to always have a manifest up to date
-fs.removeSync(paths.appManifest);
-
-// Create dev configs using our config factory, passing in razzle file as
-// options.
-let clientConfig = createConfig('web', 'dev', razzle);
-let serverConfig = createConfig('node', 'dev', razzle);
-
-// Check if razzle.config has a modify function. If it does, call it on the
-// configs we just created.
-if (razzle.modify) {
-  clientConfig = razzle.modify(
-    clientConfig,
-    { target: 'web', dev: true },
-    webpack
-  );
-  serverConfig = razzle.modify(
-    serverConfig,
-    { target: 'node', dev: true },
-    webpack
-  );
-}
-
-const serverCompiler = compile(serverConfig);
-
-// Start our server webpack instance in watch mode.
-serverCompiler.watch(
-  {
-    quiet: true,
-    stats: 'none',
-  },
-  /* eslint-disable no-unused-vars */
-  stats => {}
-);
-
-// Compile our assets with webpack
-const clientCompiler = compile(clientConfig);
-
-// Create a new instance of Webpack-dev-server for our client assets.
-// This will actually run on a different port than the users app.
-const clientDevServer = new devServer(clientCompiler, clientConfig.devServer);
-
-// Start Webpack-dev-server
-clientDevServer.listen(
-  (process.env.PORT && parseInt(process.env.PORT) + 1) || razzle.port || 3001,
-  err => {
-    if (err) {
-      logger.error(err);
+  // Check for razzle.config.js file
+  if (fs.existsSync(paths.appRazzleConfig)) {
+    try {
+      razzle = require(paths.appRazzleConfig);
+    } catch (e) {
+      clearConsole();
+      logger.error('Invalid razzle.config.js file.', e);
+      process.exit(1);
     }
   }
-);
+
+  // Delete assets.json to always have a manifest up to date
+  fs.removeSync(paths.appManifest);
+
+  // Create dev configs using our config factory, passing in razzle file as
+  // options.
+  let clientConfig = createConfig('web', 'dev', razzle);
+  let serverConfig = createConfig('node', 'dev', razzle);
+
+  // Check if razzle.config has a modify function. If it does, call it on the
+  // configs we just created.
+  if (razzle.modify) {
+    clientConfig = razzle.modify(
+      clientConfig,
+      { target: 'web', dev: true },
+      webpack
+    );
+    serverConfig = razzle.modify(
+      serverConfig,
+      { target: 'node', dev: true },
+      webpack
+    );
+  }
+
+  const serverCompiler = compile(serverConfig);
+
+  // Start our server webpack instance in watch mode.
+  serverCompiler.watch(
+    {
+      quiet: true,
+      stats: 'none',
+    },
+    /* eslint-disable no-unused-vars */
+    stats => {}
+  );
+
+  // Compile our assets with webpack
+  const clientCompiler = compile(clientConfig);
+
+  // Create a new instance of Webpack-dev-server for our client assets.
+  // This will actually run on a different port than the users app.
+  const clientDevServer = new devServer(clientCompiler, clientConfig.devServer);
+
+  // Start Webpack-dev-server
+  clientDevServer.listen(
+    (process.env.PORT && parseInt(process.env.PORT) + 1) || razzle.port || 3001,
+    err => {
+      if (err) {
+        logger.error(err);
+      }
+    }
+  );
+}
 
 // Webpack compile in a try-catch
 function compile(config) {
@@ -97,3 +100,7 @@ function compile(config) {
   }
   return compiler;
 }
+
+setPorts()
+  .then(main)
+  .catch(console.error);


### PR DESCRIPTION
Using the `choosePort` function in `react-dev-utils` as it's already a dependency.
I wrapped the start script in a `main` function, as `choosePort` returns a promise.

Also, for the dev-server port I introduced a new environment variable `PORT_DEV` to allow providing non sequential ports.
