### PR TITLE
Feature/add inspect brk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ By default, runs tests related to files changed since the last commit.
 
 To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/inspector/).
 
+### `npm start -- --inspect-brk` or `yarn start -- --inspect-brk`
+
+To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/inspector/).
+
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/packages/create-razzle-app/templates/default/README.md
+++ b/packages/create-razzle-app/templates/default/README.md
@@ -59,6 +59,10 @@ By default, runs tests related to files changed since the last commit.
 
 To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/inspector/).
 
+### `npm start -- --inspect-brk` or `yarn start -- --inspect-brk`
+
+To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/inspector/).
+
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/packages/razzle/README.md
+++ b/packages/razzle/README.md
@@ -61,6 +61,10 @@ By default, runs tests related to files changed since the last commit.
 
 To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/inspector/).
 
+### `npm start -- --inspect-brk` or `yarn start -- --inspect-brk`
+
+To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/inspector/).
+
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -274,8 +274,10 @@ module.exports = (
 
       const nodeArgs = [];
 
-      // Add --inspect flag when inspect is enabled
-      if (process.env.INSPECT_ENABLED) {
+      // Add --inspect or --inspect-brk flag when enabled
+      if (process.env.INSPECT_BRK_ENABLED) {
+        nodeArgs.push('--inspect-brk');
+      } else if (process.env.INSPECT_ENABLED) {
         nodeArgs.push('--inspect');
       }
 

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -13,7 +13,9 @@ const logger = require('razzle-dev-utils/logger');
 
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
-if (process.argv.includes('--inspect')) {
+if (process.argv.includes('--inspect-brk')) {
+  process.env.INSPECT_BRK_ENABLED = true;
+} else if (process.argv.includes('--inspect')) {
   process.env.INSPECT_ENABLED = true;
 }
 


### PR DESCRIPTION
# Inspect Break Support (--inspect-brk)
This PR adds support for --inspect-brk which is especially useful when you want to attach to the  server before any code execution using your debugger ie. vscode.

## Example Workflow: 
1. Start the server with `razzle start --inspect-brk` and wait for the compilation.
2. You will be prompted with the following  message when ready to attach a debugger:
```bash
Debugger listening on ws://127.0.0.1:9230/1a901ec9-ce71-4236-89a5-39107dcca3d9
For help see https://nodejs.org/en/docs/inspector
```
3. With Visual Studio Code you can use the following configuration in launch.json to attach to your server:
```json
    {
      "name": "Attach to Server",
      "type": "node",
      "request": "attach",
      "port": 9230,
      "restart": true
    }
```
