### PR TITLE
Adding mapCoverage to supportedKeys for Jest

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -40,6 +40,7 @@ module.exports = (resolve, rootDir) => {
     'collectCoverageFrom',
     'coverageReporters',
     'coverageThreshold',
+    'mapCoverage',
     'moduleFileExtensions',
     'moduleNameMapper',
     'modulePaths',


### PR DESCRIPTION
Adding mapCoverage option to enable correct lcov code coverage for TypeScript as discussed in #439.