### PR TITLE
Updates charset attribute name in server response

### DIFF
--- a/packages/create-razzle-app/templates/default/src/server.js
+++ b/packages/create-razzle-app/templates/default/src/server.js
@@ -26,7 +26,7 @@ server
     <html lang="">
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta charSet='utf-8' />
+        <meta charset='utf-8' />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         ${assets.client.css

--- a/packages/create-razzle-app/templates/default/src/server.js
+++ b/packages/create-razzle-app/templates/default/src/server.js
@@ -26,7 +26,7 @@ server
     <html lang="">
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta charset='utf-8' />
+        <meta charset="utf-8" />
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         ${assets.client.css


### PR DESCRIPTION
Hello 👋 , great project!

I discovered that the `<meta>` tag attribute `charset` is written as `charSet` and fixed it to its correct spelling. Not an issue at all, just thought to update for consistency.

:) 