### PR TITLE
Add `.mjs` support

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -96,7 +96,7 @@ module.exports = (
         // It is guaranteed to exist because we tweak it in `env.js`
         nodePath.split(path.delimiter).filter(Boolean)
       ),
-      extensions: ['.js', '.json', '.jsx'],
+      extensions: ['.js', '.json', '.jsx', '.mjs'],
       alias: {
         // This is required so symlinks work during development.
         'webpack/hot/poll': require.resolve('webpack/hot/poll'),
@@ -114,7 +114,7 @@ module.exports = (
         // Disable require.ensure as it's not a standard language feature.
         // { parser: { requireEnsure: false } },
         {
-          test: /\.(js|jsx)$/,
+          test: /\.(js|jsx|mjs)$/,
           enforce: 'pre',
           use: [
             {
@@ -126,7 +126,7 @@ module.exports = (
         },
         // Transform ES6 with Babel
         {
-          test: /\.(js|jsx)$/,
+          test: /\.(js|jsx|mjs)$/,
           loader: require.resolve('babel-loader'),
           include: [paths.appSrc],
           options: mainBabelOptions,
@@ -134,7 +134,7 @@ module.exports = (
         {
           exclude: [
             /\.html$/,
-            /\.(js|jsx)$/,
+            /\.(js|jsx|mjs)$/,
             /\.(ts|tsx)$/,
             /\.(vue)$/,
             /\.(less)$/,

--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -14,20 +14,22 @@ module.exports = (resolve, rootDir) => {
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
-    collectCoverageFrom: ['src/**/*.{js,jsx}'],
+    collectCoverageFrom: ['src/**/*.{js,jsx,mjs}'],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
-      '<rootDir>/src/**/__tests__/**/*.js?(x)',
-      '<rootDir>/src/**/?(*.)(spec|test).js?(x)',
+      '<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}',
+      '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',
     transform: {
-      '^.+\\.(js|jsx)$': resolve('config/jest/babelTransform.js'),
+      '^.+\\.(js|jsx|mjs)$': resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
-      '^(?!.*\\.(js|jsx|css|json)$)': resolve('config/jest/fileTransform.js'),
+      '^(?!.*\\.(js|jsx|mjs|css|json)$)': resolve(
+        'config/jest/fileTransform.js'
+      ),
     },
-    transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+    transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },


### PR DESCRIPTION
Similar to [this](https://github.com/facebookincubator/create-react-app/pull/3239) & [that](https://github.com/facebookincubator/create-react-app/pull/3537) in [CRA 1.1.0](https://github.com/facebookincubator/create-react-app/releases/tag/v1.1.0) this PR will add support of `mjs` filename extensions.

This will also fix issues like in https://github.com/jaydenseric/apollo-upload-client/issues/43#issuecomment-345687397.