### PR TITLE
Server source map support

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -324,7 +324,7 @@ module.exports = (
       config.watch = true;
       config.entry.unshift('webpack/hot/poll?300');
 
-      const nodeArgs = [];
+      const nodeArgs = ['-r', 'source-map-support/register'];
 
       // Add --inspect or --inspect-brk flag when enabled
       if (process.env.INSPECT_BRK_ENABLED) {

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -59,6 +59,7 @@
     "razzle-dev-utils": "^2.0.0",
     "react-dev-utils": "^4.0.0",
     "react-error-overlay": "^2.0.0",
+    "source-map-support": "^0.5.6",
     "start-server-webpack-plugin": "2.2.5",
     "style-loader": "0.20.3",
     "uglifyjs-webpack-plugin": "1.2.4",


### PR DESCRIPTION
This PR adds support for source maps in the server's stack trace.

The stack trace will output the file and line correctly instead of the build's one.

New output:
![captura de pantalla de 2018-02-17 22-36-26](https://user-images.githubusercontent.com/174561/36347316-37ed8c90-1433-11e8-9ffe-130bf5872626.png)

Old one:
![captura de pantalla de 2018-02-17 22-38-28](https://user-images.githubusercontent.com/174561/36347320-4d4ddd10-1433-11e8-85ab-5cb1250ca5bb.png)
