### PR TITLE
fixed webpackHotDevClient default port, if none is specified in env

### DIFF
--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -27,7 +27,7 @@ ErrorOverlay.startReportingRuntimeErrors({
   launchEditorEndpoint: url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-    port: parseInt(process.env.PORT, 10) + 1 || window.location.port,
+    port: parseInt(process.env.PORT, 10) + 1 || parseInt(window.location.port, 10) + 1,
     pathname: launchEditorEndpoint,
   }),
   onError: function() {
@@ -48,7 +48,7 @@ var connection = new SockJS(
   url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-    port: parseInt(process.env.PORT, 10) + 1 || window.location.port,
+    port: parseInt(process.env.PORT, 10) + 1 || parseInt(window.location.port, 10) + 1,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
   })


### PR DESCRIPTION
If, somehow, no `process.env.PORT` is specified, we should use `window.location.port +1` instead of `window.location` in webpackHotDevClient. 