### PR TITLE
Allow start:prod Script to Run on Windows

### DIFF
--- a/packages/create-razzle-app/lib/index.js
+++ b/packages/create-razzle-app/lib/index.js
@@ -52,7 +52,7 @@ function installWithMessageFactory(opts, isExample = false) {
       projectPath: projectPath,
       packages: isExample
         ? ['razzle']
-        : ['react', 'react-dom', 'react-router-dom', 'razzle', 'express'],
+        : ['cross-env', 'react', 'react-dom', 'react-router-dom', 'razzle', 'express'],
     })
       .then(function() {
         console.log(messages.start(projectName));

--- a/packages/create-razzle-app/templates/default/package.json
+++ b/packages/create-razzle-app/templates/default/package.json
@@ -6,7 +6,7 @@
     "start": "razzle start",
     "build": "razzle build",
     "test": "razzle test --env=jsdom",
-    "start:prod": "NODE_ENV=production node build/server.js"
+    "start:prod": "cross-env NODE_ENV=production node build/server.js"
   },
   "dependencies": {}
 }

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -183,6 +183,10 @@ module.exports = (
                     importLoaders: 1,
                   },
                 },
+                {
+                  loader: require.resolve('postcss-loader'),
+                  options: postCssOptions,
+                },
               ]
             : IS_DEV
               ? [

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -183,10 +183,6 @@ module.exports = (
                     importLoaders: 1,
                   },
                 },
-                {
-                  loader: require.resolve('postcss-loader'),
-                  options: postCssOptions,
-                },
               ]
             : IS_DEV
               ? [


### PR DESCRIPTION
This will allow the `start:prod` script to run on Windows right out of the box.

However, I think there should be a separation between runtime dependencies and development dependencies.  The `cross-env` that this PR adds and the `razzle` dependencies are just development dependencies.

This fixes issue #541.

Thanks for creating Razzle!