### PR TITLE
Need to Run CSS Resources Through postcss-loader for the Server Too

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -183,6 +183,10 @@ module.exports = (
                     importLoaders: 1,
                   },
                 },
+                {
+                  loader: require.resolve('postcss-loader'),
+                  options: postCssOptions,
+                },
               ]
             : IS_DEV
               ? [
@@ -232,6 +236,10 @@ module.exports = (
                     importLoaders: 1,
                     localIdentName: '[path]__[name]___[local]',
                   },
+                },
+                {
+                  loader: require.resolve('postcss-loader'),
+                  options: postCssOptions,
                 },
               ]
             : IS_DEV


### PR DESCRIPTION
Otherwise, the server can't resolve @import during the compilation step when a custom postcss configuration is in place. Webpack ends up failing compilation due to being unable to resolve @import.

This PR coordinates well with PR #521.
