### PR TITLE
Patching for IE11

### DIFF
--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -16,6 +16,6 @@
     "chalk": "1.1.3",
     "react-dev-utils": "4.1.0",
     "sockjs-client": "1.1.4",
-    "strip-ansi": "4.0.0"
+    "strip-ansi": "3.0.1"
   }
 }


### PR DESCRIPTION
Mirroring the patch for react-dev-utils that causes dev utils to break in IE11. strip-ansi package arrow function is causing this issue. See react-dev-utils patch PR that was accepted to fix this issue: https://github.com/facebook/create-react-app/pull/2692