### PR TITLE
Fix chunk links in with-react-loadable example

### DIFF
--- a/examples/with-react-loadable/src/server.js
+++ b/examples/with-react-loadable/src/server.js
@@ -49,7 +49,7 @@ server
       : `<script src="${assets.client.js}" crossorigin></script>`}
     ${chunks.map(chunk => (process.env.NODE_ENV === 'production'
       ? `<script src="/${chunk.file}"></script>`
-      : `<script src="http://${process.env.HOST}:${process.env.PORT + 1}/${chunk.file}"></script>`
+      : `<script src="http://${process.env.HOST}:${parseInt(process.env.PORT, 10) + 1}/${chunk.file}"></script>`
     )).join('\n')}
     <script>window.main();</script>
   </body>


### PR DESCRIPTION
Fix incorrect link to chunk scripts caused by string concatenation instead of incrementing the port number value.

`process.env.*` values are strings, so in the example file port value was `'30001'` instead of `3001`.