### PR TITLE
Add Multistep true so webpack 4 HMR can work

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -416,7 +416,9 @@ module.exports = (
       // Add client-only development plugins
       config.plugins = [
         ...config.plugins,
-        new webpack.HotModuleReplacementPlugin(),
+        new webpack.HotModuleReplacementPlugin({
+          multiStep: true
+        }),
         new webpack.DefinePlugin(dotenv.stringified),
       ];
 


### PR DESCRIPTION
Hi! Great job on this project, was playing around with the updated typescript example and noticed that the HMR does not work on the client. Looks like in webpack 4 you need to turn on `multiStep: true` to have HMR work properly.

https://webpack.js.org/plugins/hot-module-replacement-plugin/

https://github.com/webpack/webpack/issues/6693

