### PR TITLE
Bump mini-css-extract-plugin to 0.3.0

### DIFF
--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -49,7 +49,7 @@
     "file-loader": "1.1.11",
     "fs-extra": "3.0.1",
     "jest": "20.0.4",
-    "mini-css-extract-plugin": "^0.2.0",
+    "mini-css-extract-plugin": "^0.3.0",
     "object-assign": "^4.1.1",
     "postcss-flexbugs-fixes": "3.3.0",
     "postcss-loader": "^2.1.3",


### PR DESCRIPTION
In

https://github.com/jaredpalmer/razzle/blob/c185707a49f7baae71e128d3303ed04f75c587f2/packages/razzle/config/createConfig.js#L456

[contenthash] is used, but is only supported after [mini-css-extract-plugin v0.3.0](https://github.com/webpack-contrib/mini-css-extract-plugin/releases/tag/v0.3.0) so builds are breaking with

```
chunk client [entry]
static/css/bundle.[contenthash:8].css
Path variable [contenthash:8] not implemented in this context: static/css/bundle.[contenthash:8].css
```