### PR TITLE
Changed name of the about page component: Home -> About

### DIFF
--- a/examples/with-afterjs/src/About.js
+++ b/examples/with-afterjs/src/About.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-class Home extends Component {
+class About extends Component {
   render() {
     return <div>about</div>;
   }
 }
 
-export default Home;
+export default About;


### PR DESCRIPTION
I just started playing around with razzle & next.js (thanks for cool projects, @jaredpalmer!) and I noticed minor naming mistake (I think). In the with-afterjs example component that is used on the "about" page is named "Home" and I feel that it About is a better name ;). Let me know what you think. Thanks!