### PR TITLE
Include polyfills in production build

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -434,9 +434,15 @@ module.exports = (
         // runtimeChunk: true,
       };
     } else {
-      // Specify production entry point (just /client/index.js)
+      // Specify production entry point (/client/index.js)
       config.entry = {
-        client: [paths.appClientIndexJs],
+          client: [
+            // We ship a few polyfills by default but only include them if React is being placed in
+            // the default path. If you are doing some vendor bundling, you'll need to require the razzle/polyfills
+            // on your own.
+            !!dotenv.raw.REACT_BUNDLE_PATH && require.resolve('./polyfills'),
+            paths.appClientIndexJs
+          ],
       };
 
       // Specify the client output directory and paths. Notice that we have


### PR DESCRIPTION
This adds razzle/polyfills as a entry point for the client bundle in production builds. The polyfills were added to the dev config in https://github.com/jaredpalmer/razzle/pull/122, and I think it was just an oversight that they weren't added to the production config.

This should help address https://github.com/jaredpalmer/razzle/issues/538 and https://github.com/jaredpalmer/razzle/issues/522, since IE11 (and below) require these polyfills.