### PR TITLE
Update links to Node Inspector docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ By default, runs tests related to files changed since the last commit.
 
 ### `npm start -- --inspect` or `yarn start -- --inspect`
 
-To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/inspector/).
+To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
 
 ### `npm start -- --inspect-brk` or `yarn start -- --inspect-brk`
 
-To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/inspector/).
+To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
 
 ### `rs`
 


### PR DESCRIPTION
The olds links directed to a redirect page in the Node docs. Replaced them with the correct link.