### PR TITLE
add emitFile in url-loader options

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -168,6 +168,7 @@ module.exports = (
           options: {
             limit: 10000,
             name: 'static/media/[name].[hash:8].[ext]',
+            emitFile: IS_NODE ? false : true
           },
         },
 


### PR DESCRIPTION
There are 2 'static/media' directories after 'npm run build': 
-  build/public/static/media,  created by client side's build
-  build/static/media,  created by server side's build

Only the client side media path is useful.
I added 'emitFile' option to avoid server side media directory generated.