### PR TITLE
Limiting HMR to App in with-redux example

### DIFF
--- a/examples/with-redux/src/client/index.js
+++ b/examples/with-redux/src/client/index.js
@@ -14,5 +14,12 @@ hydrate(
 );
 
 if (module.hot) {
-  module.hot.accept();
+  module.hot.accept('../common/containers/App', () => {
+    hydrate(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+      document.getElementById('root')
+    );
+  });
 }


### PR DESCRIPTION
Should close https://github.com/jaredpalmer/razzle/issues/369. The react-redux Provider doesn't like the store being recreated, so this change drops client-side hot reloading of client/index.js and common/store/configureStore.js (or anything else that isn't pulled in by the App component or the root reducer).