### PR TITLE
Remove raf from examples

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+yarn.lock
+package-lock.json

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -14,7 +14,6 @@
     "react-dom": "^16.0.0"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12"
   }
 }

--- a/examples/basic/src/setupTests.js
+++ b/examples/basic/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-firebase-functions/package.json
+++ b/examples/with-firebase-functions/package.json
@@ -17,7 +17,6 @@
     "react-dom": "^16.0.0"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12"
   }
 }

--- a/examples/with-firebase-functions/src/setupTests.js
+++ b/examples/with-firebase-functions/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-jest-snapshots/package.json
+++ b/examples/with-jest-snapshots/package.json
@@ -15,7 +15,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12",
     "react-test-renderer": "^16.0.0"
   }

--- a/examples/with-jest-snapshots/src/setupTests.js
+++ b/examples/with-jest-snapshots/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-jsxstyle/package.json
+++ b/examples/with-jsxstyle/package.json
@@ -16,7 +16,6 @@
     "react-router-dom": "^4.2.2"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12"
   }
 }

--- a/examples/with-jsxstyle/src/setupTests.js
+++ b/examples/with-jsxstyle/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-material-ui/package.json
+++ b/examples/with-material-ui/package.json
@@ -8,11 +8,6 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
-  "jest": {
-    "setupFiles": [
-      "raf/polyfill"
-    ]
-  },
   "dependencies": {
     "express": "^4.15.2",
     "material-ui": "^1.0.0-beta.38",
@@ -20,7 +15,6 @@
     "react-dom": "^16.0.0"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12"
   }
 }

--- a/examples/with-react-loadable/package.json
+++ b/examples/with-react-loadable/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "express": "^4.16.2",
-    "raf": "^3.4.0",
     "razzle": "^2.0.0-alpha.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/examples/with-react-loadable/src/setupTests.js
+++ b/examples/with-react-loadable/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -15,7 +15,6 @@
     "styled-components": "^2.2.3"
   },
   "devDependencies": {
-    "raf": "^3.3.2",
     "razzle": "^2.0.0-alpha.12"
   }
 }

--- a/examples/with-styled-components/src/setupTests.js
+++ b/examples/with-styled-components/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -22,7 +22,6 @@
     "@types/react-dom": "^16.0.5",
     "@types/react-router-dom": "^4.2.6",
     "@types/webpack-env": "^1.13.6",
-    "raf": "^3.4.0",
     "razzle": "^2.0.0-alpha.12",
     "ts-jest": "^22.4.4",
     "ts-loader": "^4.2.0",

--- a/examples/with-typescript/src/setupTests.js
+++ b/examples/with-typescript/src/setupTests.js
@@ -1,1 +1,0 @@
-import 'raf/polyfill';


### PR DESCRIPTION
* Removes `raf` from all examples, since it's already included in `razzle` itself.
* Adds a `.gitignore` with `package-lock.json` and `yarn.lock` to the examples folder. This will prevent people from submitting those for new examples.