### PR TITLE
TypeScript example fixes

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -26,7 +26,7 @@
     "ts-jest": "^22.4.4",
     "ts-loader": "^4.2.0",
     "tslint": "^5.9.1",
-    "tslint-loader": "^4.2.0",
+    "tslint-loader": "^3.6.0",
     "tslint-react": "^3.5.1",
     "typescript": "^2.8.3"
   },

--- a/examples/with-typescript/razzle.config.js
+++ b/examples/with-typescript/razzle.config.js
@@ -8,8 +8,15 @@ module.exports = {
       '.ts',
       '.tsx',
     ]);
- 
 
+    // Safely locate Babel-Loader in Razzle's webpack internals
+    const babelLoader = config.module.rules.findIndex(
+      rule => rule.use[1].options && rule.use[1].options.babelrc
+    );
+
+    // Get the correct `include` option, since that hasn't changed.
+    // This tells Razzle which directories to transform.
+    const { include } = config.module.rules[babelLoader];
 
     // Locate eslint-loader and remove it (we're using tslint instead)
     config.module.rules = config.module.rules.filter(
@@ -32,15 +39,6 @@ module.exports = {
         configFile: './tslint.json',
       },
     });
-
-    // Safely locate Babel-Loader in Razzle's webpack internals
-    const babelLoader = config.module.rules.findIndex(
-      rule => rule.use[1].options && rule.use[1].options.babelrc
-    );
-
-    // Get the correct `include` option, since that hasn't changed.
-    // This tells Razzle which directories to transform.
-    const { include } = config.module.rules[babelLoader];
 
     // Declare our TypeScript loader configuration
     const tsLoader = {

--- a/examples/with-typescript/razzle.config.js
+++ b/examples/with-typescript/razzle.config.js
@@ -59,8 +59,8 @@ module.exports = {
     // If you want to replace Babel with typescript to fully speed up build
     // then do the following:
     //
-    // - COMMENT out line 55
-    // - UNCOMMENT line 67
+    // - COMMENT out line 53
+    // - UNCOMMENT line 65
     //
     // config.module.rules[babelLoader] = tsLoader;
 

--- a/examples/with-typescript/razzle.config.js
+++ b/examples/with-typescript/razzle.config.js
@@ -33,7 +33,7 @@ module.exports = {
       include,
       enforce: 'pre',
       test: /\.tsx?$/,
-      loader: 'tslint-loader',
+      loader: require.resolve('tslint-loader'),
       options: {
         emitErrors: true,
         configFile: './tslint.json',
@@ -44,7 +44,7 @@ module.exports = {
     const tsLoader = {
       include,
       test: /\.tsx?$/,
-      loader: 'ts-loader',
+      loader: require.resolve('ts-loader'),
       options: {
         transpileOnly: true,
       },


### PR DESCRIPTION
* `package.json` defined a non-existent version of `tslint-loader` (version 4.2.0). The latest version is 3.6.0 (fixes #600)
* On `razzle.config.js`, `include` is used before being defined.