### PR TITLE
Fix useBabel use option in razzzle-plugin-typescript

### DIFF
--- a/packages/razzle-plugin-typescript/index.js
+++ b/packages/razzle-plugin-typescript/index.js
@@ -57,7 +57,7 @@ function modify(baseConfig, { target, dev }, webpack, userOptions = {}) {
   if (options.useBabel) {
     // If using babel, also add babel-loader to ts files,
     // so we can use babel plugins on tsx files too
-    tsLoader.use = [babelLoader.use[1], ...tsLoader.use];
+    tsLoader.use = [...babelLoader.use, ...tsLoader.use];
   } else {
     // If not using babel, remove it
     config.module.rules = config.module.rules.filter(


### PR DESCRIPTION
This seems to be broken since 2.0. I'm not sure why `[1]` is specified as the index for the `use` option here, but the babelLoader is at index zero. Figured it'd be less error prone to just spread this as is done for the `tsLoader.use`