### PR TITLE
add HOST when starting webpack-dev-server in start.js

### DIFF
--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -20,6 +20,8 @@ if (process.argv.includes('--inspect-brk')) {
   process.env.INSPECT_ENABLED = true;
 }
 
+const HOST = process.env.HOST || '0.0.0.0';
+
 function main() {
   // Optimistically, we make the console look exactly like the output of our
   // FriendlyErrorsPlugin during compilation, so the user has immediate feedback.
@@ -69,6 +71,7 @@ function main() {
   // Start Webpack-dev-server
   clientDevServer.listen(
     (process.env.PORT && parseInt(process.env.PORT) + 1) || razzle.port || 3001,
+    HOST,
     err => {
       if (err) {
         logger.error(err);


### PR DESCRIPTION
There was no HOST option when starting the `webpack-dev-server` in `start.js`

```
  clientDevServer.listen(
    (process.env.PORT && parseInt(process.env.PORT) + 1) || razzle.port || 3001,
    err => {
      if (err) {  // would never get here
        logger.error(err);
      }
    }
  );
```
