### PR TITLE
Update babel-eslint to 8.x ...

### DIFF
--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -32,7 +32,7 @@
     "assets-webpack-plugin": "3.5.1",
     "autoprefixer": "7.1.1",
     "babel-core": "6.25.0",
-    "babel-eslint": "7.2.3",
+    "babel-eslint": "8.2.3",
     "babel-jest": "20.0.3",
     "babel-loader": "7.1.1",
     "babel-preset-razzle": "^2.0.0",


### PR DESCRIPTION
Update `babel-eslint` to 8.x so that decorators will work using `babel-plugin-transform-decorators-legacy`. See: https://github.com/babel/babel-eslint/issues/275.

Other option would be to update the docs and add documentation for the fix by adding manually the following depedency: `yarn add babel-eslint` or `npm install babel-eslint` (should install `babel-eslint` 8.x).