### PR TITLE
Bump Jest to v23

### DIFF
--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-react": "^7.3.0",
     "file-loader": "^1.1.11",
     "fs-extra": "3.0.1",
-    "jest": "^22.4.3",
+    "jest": "^23.1.0",
     "mini-css-extract-plugin": "^0.4.0",
     "object-assign": "^4.1.1",
     "postcss-flexbugs-fixes": "3.3.0",


### PR DESCRIPTION
This is just another version bump, 22 has an annoying issue where it's unable to update some snapshots when launched with --watch (as razzle test does). See https://github.com/facebook/jest/pull/5696.