### PR TITLE
preserve the full --inspect= flag as passed to yarn start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ You can again view your application at `http://localhost:3000`
 Runs the test watcher (Jest) in an interactive mode.
 By default, runs tests related to files changed since the last commit.
 
-### `npm start -- --inspect` or `yarn start -- --inspect`
+### `npm start -- --inspect=[host:port]` or `yarn start -- --inspect=[host:port]`
 
-To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
+To debug the node server, you can use `razzle start --inspect`. This will start the node server and enable the inspector agent. The `=[host:port]` is optional and defaults to `=127.0.0.1:9229`. For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
 
-### `npm start -- --inspect-brk` or `yarn start -- --inspect-brk`
+### `npm start -- --inspect-brk=[host:port]` or `yarn start -- --inspect-brk=[host:port]`
 
-To debug the node server, you can use `razzle start --inspect-brk`. This will start the node server, enable the inspector agent and Break before user code starts. For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
+This is the same as --inspect, but will also break before user code starts. (to give a debugger time to attach before early code runs) For more information, see [this](https://nodejs.org/en/docs/guides/debugging-getting-started/).
 
 ### `rs`
 

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -326,7 +326,7 @@ module.exports = (
 
       const nodeArgs = ['-r', 'source-map-support/register'];
 
-      // Add --inspect or --inspect-brk flag when enabled
+      // Passthrough --inspect and --inspect-brk flags (with optional [host:port] value) to node
       if (process.env.INSPECT_BRK) {
         nodeArgs.push(process.env.INSPECT_BRK);
       } else if (process.env.INSPECT) {

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -327,10 +327,10 @@ module.exports = (
       const nodeArgs = ['-r', 'source-map-support/register'];
 
       // Add --inspect or --inspect-brk flag when enabled
-      if (process.env.INSPECT_BRK_ENABLED) {
-        nodeArgs.push('--inspect-brk');
-      } else if (process.env.INSPECT_ENABLED) {
-        nodeArgs.push('--inspect');
+      if (process.env.INSPECT_BRK) {
+        nodeArgs.push(process.env.INSPECT_BRK);
+      } else if (process.env.INSPECT) {
+        nodeArgs.push(process.env.INSPECT);
       }
 
       config.plugins = [

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -14,8 +14,12 @@ const setPorts = require('razzle-dev-utils/setPorts');
 
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
-process.env.INSPECT_BRK = process.argv.find((arg) => arg.match(/--inspect-brk(=|$)/)) || '';
-process.env.INSPECT = process.argv.find((arg) => arg.match(/--inspect(=|$)/)) || '';
+// Capture any --inspect or --inspect-brk flags (with optional values) so that we
+// can pass them when we invoke nodejs
+process.env.INSPECT_BRK =
+  process.argv.find(arg => arg.match(/--inspect-brk(=|$)/)) || '';
+process.env.INSPECT =
+  process.argv.find(arg => arg.match(/--inspect(=|$)/)) || '';
 
 function main() {
   // Optimistically, we make the console look exactly like the output of our

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -14,11 +14,8 @@ const setPorts = require('razzle-dev-utils/setPorts');
 
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
-if (process.argv.includes('--inspect-brk')) {
-  process.env.INSPECT_BRK_ENABLED = true;
-} else if (process.argv.includes('--inspect')) {
-  process.env.INSPECT_ENABLED = true;
-}
+process.env.INSPECT_BRK = process.argv.find((arg) => arg.match(/--inspect-brk(=|$)/)) || '';
+process.env.INSPECT = process.argv.find((arg) => arg.match(/--inspect(=|$)/)) || '';
 
 function main() {
   // Optimistically, we make the console look exactly like the output of our


### PR DESCRIPTION
NodeJS's inspect flag takes an optional =IP:PORT. Razzle is currently ignoring that and treating it as a simple boolean.

Docs: https://nodejs.org/api/cli.html#cli_inspect_host_port

This PR renames the INSPECT_ENABLED env var to INSPECT, and stores the flag as it was passed to yarn start. (and the same for INSPECT_BRK_ENABLED)