### PR TITLE
Implement a Flow plugin for Razzle

### DIFF
--- a/packages/razzle-plugin-flow/.eslintrc
+++ b/packages/razzle-plugin-flow/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "jest": true,
+    "node": true
+  }
+}

--- a/packages/razzle-plugin-flow/README.md
+++ b/packages/razzle-plugin-flow/README.md
@@ -1,0 +1,27 @@
+# razzle-plugin-flow
+
+This package contains a plugin for using Flow with Razzle.
+
+## Usage in Razzle Projects
+
+Install the plugin:
+
+```
+yarn add razzle-plugin-flow
+```
+
+Initialize Flow:
+
+```
+yarn flow init
+```
+
+Using the plugin with the default options
+
+```js
+// razzle.config.js
+
+module.exports = {
+  plugins: ['flow'],
+};
+```

--- a/packages/razzle-plugin-flow/helpers.js
+++ b/packages/razzle-plugin-flow/helpers.js
@@ -1,0 +1,10 @@
+'use strict';
+const makeLoaderFinder = require('razzle-dev-utils/makeLoaderFinder');
+
+const babelLoaderFinder = makeLoaderFinder('babel-loader');
+const eslintLoaderFinder = makeLoaderFinder('eslint-loader');
+
+module.exports = {
+  eslintLoaderFinder,
+  babelLoaderFinder,
+};

--- a/packages/razzle-plugin-flow/index.js
+++ b/packages/razzle-plugin-flow/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const FlowWebpackPlugin = require('flow-webpack-plugin');
+const { babelLoaderFinder, eslintLoaderFinder } = require('./helpers');
+
+function addFlowPlugin(config) {
+  config.plugins.push(
+    new FlowWebpackPlugin({
+      failOnError: false,
+      failOnErrorWatch: false,
+      reportingSeverity: 'error',
+      printFlowOutput: true,
+      flowArgs: ['--color=always'],
+      verbose: false,
+    })
+  );
+}
+
+function modifyBabelLoader(config) {
+  // Safely locate Babel-Loader in Razzle's webpack internals
+  const babelLoader = config.module.rules.find(babelLoaderFinder);
+  if (!babelLoader) {
+    throw new Error(
+      `'babel-loader' was erased from config, we need it to add a preset for Flow`
+    );
+  }
+
+  babelLoader.use[0].options.presets.push(`flow`);
+}
+
+function modifyEslintLoader(config) {
+  // Safely locate Eslint-Loader in Razzle's webpack internals
+  const eslintLoader = config.module.rules.find(eslintLoaderFinder);
+  if (!eslintLoader) {
+    throw new Error(
+      `'eslint-loader' was erased from config, we need it to add a preset for Flow`
+    );
+  }
+
+  const eslintOptions = eslintLoader.use[0].options;
+  if (!eslintOptions.plugins) {
+    eslintOptions.plugins = [];
+  }
+
+  eslintOptions.plugins.push(`flowtype`);
+
+  eslintOptions.baseConfig.extends.push(`plugin:flowtype/recommended`);
+}
+
+function modify(baseConfig) {
+  const config = Object.assign({}, baseConfig);
+
+  addFlowPlugin(config);
+  modifyBabelLoader(config);
+  modifyEslintLoader(config);
+
+  return config;
+}
+
+module.exports = modify;

--- a/packages/razzle-plugin-flow/package.json
+++ b/packages/razzle-plugin-flow/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "razzle-plugin-flow",
+  "version": "2.2.0",
+  "description": "Use Flow with Razzle",
+  "main": "index.js",
+  "repository": "git@github.com:jaredpalmer/razzle.git",
+  "author": "Rory Hunter <roryhunter2@gmail.com>",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "babel-preset-flow": "^6.23.0",
+    "eslint-plugin-flowtype": "^2.49.3",
+    "flow-bin": "^0.74.0",
+    "flow-webpack-plugin": "^1.2.0"
+  },
+  "devDependencies": {
+    "razzle": "^2.2.0"
+  },
+  "peerDependencies": {}
+}

--- a/packages/razzle-plugin-flow/tests/index.test.js
+++ b/packages/razzle-plugin-flow/tests/index.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const FlowWebpackPlugin = require('flow-webpack-plugin');
+const createConfig = require('razzle/config/createConfig');
+const pluginFunc = require('../index');
+const { eslintLoaderFinder, babelLoaderFinder } = require('../helpers');
+
+// Don't allow the presence of files in this plugin repository to affect
+// the tests.
+jest.mock('fs-extra', () => ({ existsSync: () => false }));
+
+describe('razzle-flow-plugin', () => {
+  let config;
+  beforeAll(() => {
+    config = createConfig('web', 'dev', {
+      plugins: [{ func: pluginFunc }],
+    });
+  });
+
+  it('should add a Flow webpack plugin', () => {
+    const flowPlugin = config.plugins.find(
+      plugin => plugin instanceof FlowWebpackPlugin
+    );
+
+    expect(flowPlugin).not.toBeUndefined();
+  });
+
+  it('should modify babel-loader', () => {
+    const rule = config.module.rules.find(babelLoaderFinder);
+    expect(rule.use[0].options.presets).toContain('flow');
+  });
+
+  it('should modify eslint-loader', () => {
+    const rule = config.module.rules.find(eslintLoaderFinder);
+    expect(rule.use[0].options.baseConfig.extends).toContain(
+      'plugin:flowtype/recommended'
+    );
+    expect(rule.use[0].options.plugins).toContain('flowtype');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@arr/every@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@arr/every/-/every-1.0.0.tgz#314f8168f50ae48a032cfdad5fdb436f464a97ac"
+
 "@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
@@ -1175,6 +1179,14 @@ babel-jest@^23.0.1:
 babel-loader@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
+  dependencies:
+    find-cache-dir "^1.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+
+babel-loader@7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.4.tgz#e3463938bd4e6d55d1c174c5485d406a188ed015"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
@@ -3028,7 +3040,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.2:
+create-react-class@^15.5.1, create-react-class@^15.6.2:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
@@ -3881,6 +3893,12 @@ eslint-plugin-flowtype@^2.35.0:
   dependencies:
     lodash "^4.15.0"
 
+eslint-plugin-flowtype@^2.49.3:
+  version "2.49.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz#ccca6ee5ba2027eb3ed36bc2ec8c9a842feee841"
+  dependencies:
+    lodash "^4.17.10"
+
 eslint-plugin-import@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
@@ -4621,6 +4639,14 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+flow-bin@^0.74.0:
+  version "0.74.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.74.0.tgz#8017bb00efb37cbe8d81fbb7f464038bde06adc9"
+
+flow-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/flow-webpack-plugin/-/flow-webpack-plugin-1.2.0.tgz#1958821d16135028e391cad5ee2f3a4fa78197ec"
+
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
@@ -5329,6 +5355,15 @@ helmet@^3.9.0:
 hide-powered-by@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.0.0.tgz#4a85ad65881f62857fc70af7174a1184dccce32b"
+
+history@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
 
 history@^4.7.2:
   version "4.7.2"
@@ -7905,6 +7940,12 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+matchit@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/matchit/-/matchit-1.0.6.tgz#825da06468bd324f0219ebe28e12a41bfb5524c4"
+  dependencies:
+    "@arr/every" "^1.0.0"
+
 material-ui@^1.0.0-beta.38:
   version "1.0.0-beta.41"
   resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.41.tgz#0869bed008caa10003ab20ea726476b560c23160"
@@ -8820,7 +8861,7 @@ parse5@^3.0.3:
   dependencies:
     "@types/node" "*"
 
-parseurl@^1.3.0, parseurl@~1.3.2:
+parseurl@^1.3.0, parseurl@^1.3.2, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
@@ -8965,6 +9006,13 @@ pluralize@^7.0.0:
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+
+polka@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/polka/-/polka-0.3.4.tgz#685bc3529a4582378853d568aa15d78eb3318eb3"
+  dependencies:
+    parseurl "^1.3.2"
+    trouter "^1.0.0"
 
 popper.js@^1.12.9:
   version "1.14.3"
@@ -9516,6 +9564,13 @@ prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.5.6:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 protobufjs@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.2.tgz#59748d7dcf03d2db22c13da9feb024e16ab80c91"
@@ -9624,7 +9679,7 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.2.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -9988,6 +10043,30 @@ react-router-dom@^4.2.2:
     loose-envify "^1.3.1"
     prop-types "^15.5.4"
     react-router "^4.2.0"
+    warning "^3.0.0"
+
+react-router-redux@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
+
+react-router-scroll@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/react-router-scroll/-/react-router-scroll-0.4.2.tgz#4b90e8707edf96eba7f066d94c5b4338bd6848b7"
+  dependencies:
+    prop-types "^15.5.6"
+    scroll-behavior "^0.9.3"
+    warning "^3.0.0"
+
+react-router@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"
+  dependencies:
+    create-react-class "^15.5.1"
+    history "^3.0.0"
+    hoist-non-react-statics "^2.3.1"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    prop-types "^15.5.6"
     warning "^3.0.0"
 
 react-router@^4.2.0:
@@ -10674,6 +10753,13 @@ schema-utils@^0.4.0, schema-utils@^0.4.3, schema-utils@^0.4.4, schema-utils@^0.4
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
+scroll-behavior@^0.9.3:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.9.tgz#ebfe0658455b82ad885b66195215416674dacce2"
+  dependencies:
+    dom-helpers "^3.2.1"
+    invariant "^2.2.2"
+
 scroll@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/scroll/-/scroll-2.0.3.tgz#0951b785544205fd17753bc3d294738ba16fc2ab"
@@ -10732,7 +10818,7 @@ serve-index@^1.7.2:
     mime-types "~2.1.17"
     parseurl "~1.3.2"
 
-serve-static@1.13.2:
+serve-static@1.13.2, serve-static@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
   dependencies:
@@ -11686,6 +11772,12 @@ trim-off-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+trouter@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/trouter/-/trouter-1.1.0.tgz#ce0ad2aaa4f13af21e34785079c3352298b9259a"
+  dependencies:
+    matchit "^1.0.0"
 
 ts-jest@^22.4.5:
   version "22.4.6"


### PR DESCRIPTION
This PR adds a plugin that adds Flow typing. The plugin:

* Adds a webpack plugin to run Flow typing during the Webpack build
* Amends the Babel config to add the Flow preset
* Amends the ESLint config to add the Flow preset and recommended rules

To test:

1. Create a Razzle app
2. Add the plugin.
3. Start it (it should start cleanly)
4. Edit `src/App.js` and add the line `const foo: number = 's';` e.g. after the imports
5. ESLint will complain about the unused variable but cope with the Flow syntax.
6. Flow will complain about a type mismatch