### PR TITLE
Adding testEnvironmentOptions to supportedKeys for Jest

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -49,6 +49,7 @@ module.exports = (resolve, rootDir) => {
     'snapshotSerializers',
     'setupFiles',
     'testMatch',
+    'testEnvironmentOptions',
     'testResultsProcessor',
     'transform',
     'transformIgnorePatterns',


### PR DESCRIPTION
When upgrading to the latest version of razzle (2.2.0), the tests that are testing automatic injection of script tags in our code are failing. This is due to #656 which upgraded Jest to version 23 which has different defaults. 

The new Jest configures JSDOM to not load <script> resources by default, which we would want to customize. The configuration to set in order to fix the bug in our case is:

```json
  "jest": {
    "testEnvironmentOptions": {
      "resources": "usable"
    }
  }
```

This configuration is not so uncommon e.g.:
https://stackoverflow.com/questions/49468588/jest-enzyme-image-onload-callback-not-being-ran#49482563