### PR TITLE
add support for function as plugin

### DIFF
--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -6,6 +6,10 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
     return runPlugin({ name: plugin }, config, { target, dev }, webpack);
   }
 
+  if (typeof plugin === 'function') {
+    return plugin(config, { target, dev }, webpack);
+  }
+
   if (typeof plugin.func === 'function') {
     // Used for writing plugin tests
     return plugin.func(config, { target, dev }, webpack, plugin.options);


### PR DESCRIPTION
```js
module.exports = {
  plugins: [
    // import local plugin
    require('./myPlugin'),
    // import scoped plugin
    require('@company/my-plugin'),
    // add plugin options
    require('my-plugin')(options),
  ]
}
```

#697
#670
