### PR TITLE
Fix .mjs issue with GraphQL 0.13.2

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -142,6 +142,12 @@ module.exports = (
           ],
           include: paths.appSrc,
         },
+        // Avoid "require is not defined" errors
+        {
+          test: /\.mjs$/,
+          include: /node_modules/,
+          type: "javascript/auto",
+        },
         // Transform ES6 with Babel
         {
           test: /\.(js|jsx|mjs)$/,

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -114,7 +114,7 @@ module.exports = (
         // It is guaranteed to exist because we tweak it in `env.js`
         nodePath.split(path.delimiter).filter(Boolean)
       ),
-      extensions: ['.js', '.json', '.jsx', '.mjs'],
+      extensions: ['.mjs', '.jsx', '.js', '.json'],
       alias: {
         // This is required so symlinks work during development.
         'webpack/hot/poll': require.resolve('webpack/hot/poll'),


### PR DESCRIPTION
With Razzle v2.2.0 + GraphQL v0.13.2, I was seeing tons of:

> Can't reexport the named export 'BREAK' from non EcmaScript module (only default export is available)

After doing some research, this has already been reported as a break in `graphql@0.13.1` when they introduced `.mjs` support:

> https://github.com/graphql/graphql-js/issues/1272#issuecomment-377384574

Luckily, the fix is simply re-ordering webpack's `extensions` to give precedence to `.mjs` before `.js`:

> https://github.com/graphql/graphql-js/issues/1272#issuecomment-377384574

Confirmed the fix worked in my local repo:

```diff
patch-package
--- a/node_modules/razzle/config/createConfig.js
+++ b/node_modules/razzle/config/createConfig.js
@@ -100,7 +100,7 @@ module.exports = (
         // It is guaranteed to exist because we tweak it in `env.js`
         nodePath.split(path.delimiter).filter(Boolean)
       ),
-      extensions: ['.js', '.json', '.jsx', '.mjs'],
+      extensions: ['.mjs', '.jsx', '.js', '.json'],
       alias: {
         // This is required so symlinks work during development.
         'webpack/hot/poll': require.resolve('webpack/hot/poll'),
@@ -128,6 +128,12 @@ module.exports = (
           ],
           include: paths.appSrc,
         },
+        // Avoid "require is not defined" errors
+        {
+          test: /\.mjs$/,
+          include: /node_modules/,
+          type: "javascript/auto",
+        },
         // Transform ES6 with Babel
         {
           test: /\.(js|jsx|mjs)$/,
```