### PR TITLE
[RFR] Fix production sourcemaps

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -106,7 +106,7 @@ module.exports = (
     // Specify target (either 'node' or 'web')
     target: target,
     // Controversially, decide on sourcemaps.
-    devtool: 'cheap-module-source-map',
+    devtool: IS_DEV ? 'cheap-module-source-map' : 'source-map',
     // We need to tell webpack how to resolve both Razzle's node_modules and
     // the users', so we use resolve and resolveLoader.
     resolve: {
@@ -146,7 +146,7 @@ module.exports = (
         {
           test: /\.mjs$/,
           include: /node_modules/,
-          type: "javascript/auto",
+          type: 'javascript/auto',
         },
         // Transform ES6 with Babel
         {


### PR DESCRIPTION
Currently, all source maps are `cheap-module-source-map`. Even if it seems to be production ready according to [official Webpack doc](https://webpack.js.org/configuration/devtool/#devtool), I got empty sourcemap once built. 

Using `source-map` fixes the issue. And, even if it is slower, it occurs only at build time. 

Closes #463.