### PR TITLE
Use the correct port when PORT is not set

### DIFF
--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -27,7 +27,7 @@ ErrorOverlay.startReportingRuntimeErrors({
   launchEditorEndpoint: url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-    port: parseInt(process.env.PORT, 10) + 1 || window.location.port,
+    port: parseInt(process.env.PORT || window.location.port, 10) + 1,
     pathname: launchEditorEndpoint,
   }),
   onError: function() {
@@ -48,7 +48,7 @@ var connection = new SockJS(
   url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-    port: parseInt(process.env.PORT, 10) + 1 || window.location.port,
+    port: parseInt(process.env.PORT || window.location.port, 10) + 1,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
   })


### PR DESCRIPTION
I'm running a custom config where `PORT` is not hardcoded into the bundle, because I'm using that variable in a Docker container and need it to be dynamic.

This solves usages of `webpackHotDevClient` when `PORT` is not set inside the bundle.