### PR TITLE
Fix for '[HMR] You need to restart the application!' on server sided error

### DIFF
--- a/packages/create-razzle-app/templates/default/src/index.js
+++ b/packages/create-razzle-app/templates/default/src/index.js
@@ -1,5 +1,6 @@
-import app from './server';
 import http from 'http';
+
+let app = require('./server').default;
 
 const server = http.createServer(app);
 
@@ -18,7 +19,7 @@ if (module.hot) {
 
   const noErrors = () => {
     try {
-      require('./server').default;
+      require('./server.js').default;
     } catch (error) {
       console.error(error);
       return false;
@@ -30,9 +31,9 @@ if (module.hot) {
     if (noErrors()) {
       console.log('🔁  HMR Reloading `./server`...');
       server.removeListener('request', currentApp);
-      const newApp = require('./server').default;
-      server.on('request', newApp);
-      currentApp = newApp;
+      app = require('./server').default;
+      server.on('request', app);
+      currentApp = app;
     }
   });
 }

--- a/packages/create-razzle-app/templates/default/src/index.js
+++ b/packages/create-razzle-app/templates/default/src/index.js
@@ -19,7 +19,7 @@ if (module.hot) {
 
   const noErrors = () => {
     try {
-      require('./server.js').default;
+      require('./server').default;
     } catch (error) {
       console.error(error);
       return false;

--- a/packages/create-razzle-app/templates/default/src/index.js
+++ b/packages/create-razzle-app/templates/default/src/index.js
@@ -16,11 +16,23 @@ server.listen(process.env.PORT || 3000, error => {
 if (module.hot) {
   console.log('✅  Server-side HMR Enabled!');
 
+  const noErrors = () => {
+    try {
+      require('./server').default;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+    return true;
+  };
+
   module.hot.accept('./server', () => {
-    console.log('🔁  HMR Reloading `./server`...');
-    server.removeListener('request', currentApp);
-    const newApp = require('./server').default;
-    server.on('request', newApp);
-    currentApp = newApp;
+    if (noErrors()) {
+      console.log('🔁  HMR Reloading `./server`...');
+      server.removeListener('request', currentApp);
+      const newApp = require('./server').default;
+      server.on('request', newApp);
+      currentApp = newApp;
+    }
   });
 }


### PR DESCRIPTION
When you make an error (e.g. undefined variable) somewhere in the server.js, you need to restart the application. To prevent this you should only restart the server when there's no errors.