### PR TITLE
Update css chunks: use [name] instead of [id]

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -495,6 +495,7 @@ module.exports = (
         // Extract our CSS into a files.
         new MiniCssExtractPlugin({
           filename: 'static/css/bundle.[contenthash:8].css',
+          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
           // allChunks: true because we want all css to be included in the main
           // css bundle when doing code splitting to avoid FOUC:
           // https://github.com/facebook/create-react-app/issues/2415


### PR DESCRIPTION
Would be better to have ```build/static/css/name.5f16c5ad.chunk.css``` than ```build/static/css/3.bundle.5f16c5ad.css```