### PR TITLE
Set template package version back to 0.1.0

### DIFF
--- a/packages/create-razzle-app/templates/default/package.json
+++ b/packages/create-razzle-app/templates/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-razzle-app",
-  "version": "2.0.0-alpha.8",
+  "version": "0.1.0",
   "license": "MIT",
   "scripts": {
     "start": "razzle start",


### PR DESCRIPTION
It looks like in the v2 update the template package version was changed, but it should probably still be `0.1.0`.