### PR TITLE
CLIENT_PUBLIC_PATH default was being set in two places

### DIFF
--- a/packages/razzle/config/env.js
+++ b/packages/razzle/config/env.js
@@ -74,7 +74,7 @@ function getClientEnvironment(target, options) {
         PUBLIC_PATH: process.env.PUBLIC_PATH || '/',
         // CLIENT_PUBLIC_PATH is a PUBLIC_PATH for NODE_ENV === 'development' && BUILD_TARGET === 'client'
         // It's useful if you're running razzle in a non-localhost container. Ends in a /
-        CLIENT_PUBLIC_PATH: process.env.CLIENT_PUBLIC_PATH || '/',
+        CLIENT_PUBLIC_PATH: process.env.CLIENT_PUBLIC_PATH,
         // The public dir changes between dev and prod, so we use an environment
         // variable available to users.
         RAZZLE_PUBLIC_DIR:


### PR DESCRIPTION
CLIENT_PUBLIC_PATH default was being set in two places that computed different values. Remove the erroneous one.