### PR TITLE
allow subdirectories in src directory for reason example

### DIFF
--- a/examples/with-reason-react/bsconfig.json
+++ b/examples/with-reason-react/bsconfig.json
@@ -12,7 +12,8 @@
   "bs-dependencies": ["reason-react"],
   "sources": [
     {
-      "dir": "src"
+      "dir": "src",
+      "subdirs": true
     }
   ],
   "package-specs": [


### PR DESCRIPTION
this allows to create directories, so that you can have your reason files in a folder structure of your choice.