### PR TITLE
to fix #743 (yarnpkg can't be picked up)

### DIFF
--- a/packages/create-razzle-app/lib/utils/get-install-cmd.js
+++ b/packages/create-razzle-app/lib/utils/get-install-cmd.js
@@ -10,7 +10,7 @@ module.exports = function getInstallCmd() {
   }
 
   try {
-    execa.sync('yarnpkg', '--version');
+    execa.sync('yarnpkg', ['--version']);
     cmd = 'yarn';
   } catch (e) {
     cmd = 'npm';


### PR DESCRIPTION
error code from debug
```
TypeError: Cannot create property 'windowsVerbatimArguments' on string '--version'
    at parseNonShell (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\cross-spawn\lib\parse.js:50:49)
    at Function.parse [as _parse] (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\cross-spawn\lib\parse.js:110:49)
    at handleArgs (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\execa\index.js:28:23)
    at Function.module.exports.sync (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\execa\index.js:268:17)
    at getInstallCmd (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\create-razzle-app\lib\utils\get-install-cmd.js:13:11)
    at install (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\create-razzle-app\lib\utils\install.js:19:22)
    at installWithMessage (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\create-razzle-app\lib\index.js:50:12)
    at tryCallOne (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\promise\lib\core.js:37:12)
    at C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\promise\lib\core.js:123:15
    at flush (C:\Users\???\AppData\Local\Yarn\Data\global\node_modules\asap\raw.js:50:29)
```

root cause analysis is below:

[`execa.sync`](https://github.com/sindresorhus/execa#execasyncfile-arguments-options) is as below

```js
execa.sync(file, [arguments], [options])
```
as the current `create-razzle-app` code is 
```js
 execa.sync('yarnpkg', '--version'); 
```

The second parameter is causing issue and `cross-spawn` package would mix the args to options object. 

