### PR TITLE
Fix Jest patterns in examples/with-typescript

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -31,8 +31,8 @@ Thus we add `ts-jest` and `@types/jest` to our dev dependencies. Then we augment
   ...
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js",
-      "^.+\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",
+      "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js",
+      "\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/node_modules/razzle/config/jest/fileTransform.js"
     },
     "testMatch": [

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -31,8 +31,8 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js",
-      "^.+\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",
+      "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js",
+      "\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/node_modules/razzle/config/jest/fileTransform.js"
     },
     "testMatch": [


### PR DESCRIPTION
Fixes Jest patterns so that TS-preprocessor doesn't get used for arbitrary files with `ts` in the name. 

A `$` is required to ensure the extension is being matched, otherwise the regex with match other parts of the filename. For example: <code>src/componen<b>ts</b>/Main/Main.css</code>

See #426 