### PR TITLE
Only create one watcher for the server

### DIFF
--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -51,9 +51,18 @@ function main() {
   const clientCompiler = compile(clientConfig);
   const serverCompiler = compile(serverConfig);
 
+  // Instatiate a variable to track server watching
+  let watching;
+
   // Start our server webpack instance in watch mode after assets compile
   clientCompiler.plugin('done', () => {
-    serverCompiler.watch(
+    // If we've already started the server watcher,
+    // bail early.
+    if (watching) {
+      return;
+    }
+    // Otherwise, create a new watcher for our server code.
+    watching = serverCompiler.watch(
       {
         quiet: true,
         stats: 'none',

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -56,18 +56,13 @@ function main() {
 
   // Start our server webpack instance in watch mode after assets compile
   clientCompiler.plugin('done', () => {
-    // If we've already started the server watcher,
-    // bail early.
+    // If we've already started the server watcher, bail early.
     if (watching) {
       return;
     }
     // Otherwise, create a new watcher for our server code.
     watching = serverCompiler.watch(
-      {
-        quiet: true,
-        stats: 'none',
-      },
-      /* eslint-disable no-unused-vars */
+      { quiet: true, stats: 'none' } /* eslint-disable no-unused-vars */,
       stats => {}
     );
   });


### PR DESCRIPTION
This updates our development mode such that one, and only one, webpack watcher is used for the server. Previously, any change to client or shared code would generate new watcher. 

Closes #875 