### PR TITLE
Fix startReportingRuntimeErrors warning

### DIFF
--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -16,6 +16,26 @@ var launchEditorEndpoint = require('react-dev-utils/launchEditorEndpoint');
 var formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 var ErrorOverlay = require('react-error-overlay');
 
+ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
+  // Keep this sync with errorOverlayMiddleware.js
+  fetch(
+    url.format({
+      protocol: window.location.protocol,
+      hostname: window.location.hostname,
+      port: parseInt(process.env.PORT || window.location.port, 10) + 1,
+      pathname: launchEditorEndpoint,
+      search:
+        '?fileName=' +
+        window.encodeURIComponent(errorLocation.fileName) +
+        '&lineNumber=' +
+        window.encodeURIComponent(errorLocation.lineNumber || 1) +
+        '&colNumber=' +
+        window.encodeURIComponent(errorLocation.colNumber || 1),
+    }),
+    { mode: 'no-cors' }
+  );
+});
+
 // We need to keep track of if there has been a runtime error.
 // Essentially, we cannot guarantee application state was not corrupted by the
 // runtime error. To prevent confusing behavior, we forcibly reload the entire
@@ -24,12 +44,6 @@ var ErrorOverlay = require('react-error-overlay');
 // See https://github.com/facebookincubator/create-react-app/issues/3096
 var hadRuntimeError = false;
 ErrorOverlay.startReportingRuntimeErrors({
-  launchEditorEndpoint: url.format({
-    protocol: window.location.protocol,
-    hostname: window.location.hostname,
-    port: parseInt(process.env.PORT || window.location.port, 10) + 1,
-    pathname: launchEditorEndpoint,
-  }),
   onError: function() {
     hadRuntimeError = true;
   },


### PR DESCRIPTION
Fixes the startReportingRuntimeErrors warning reported in https://github.com/jaredpalmer/razzle/pull/839.

Mainly copied from https://github.com/facebook/create-react-app/commit/00ed100b26adc519fd90e09ebffd83c8d7dc4343#diff-5166b8ed2c51bdab6a247a95b14ff595 but with changes to open on the correct port.

Needed to add a `{ mode: 'no-cors' }` to prevent a CORS issue. I have not explored if there is a better workaround.