### PR TITLE
Relative Sass imports do not work in production builds

### DIFF
--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -29,7 +29,10 @@ const defaultOptions = {
       includePaths: [paths.appNodeModules],
     },
     prod: {
-      sourceMap: false,
+      // XXX Source maps are required for the resolve-url-loader to properly
+      // function. Disable them in later stages if you do not want source maps.
+      sourceMap: true,
+      sourceMapContents: false,
       includePaths: [paths.appNodeModules],
     },
   },
@@ -107,8 +110,8 @@ module.exports = (
         : [
             dev ? styleLoader : MiniCssExtractPlugin.loader,
             cssLoader,
-            resolveUrlLoader,
             postCssLoader,
+            resolveUrlLoader,
             sassLoader,
           ],
     },


### PR DESCRIPTION
Hi,

I have been using Razzle with `razzle-plugin-scss` for an internal project I'm working on. However, I found that our production builds fail when doing relative imports in Sass files.

After inspecting the source code of `razzle-plugin-scss`, I found that it uses [resolve-url-loader](https://github.com/bholloway/resolve-url-loader) to resolve relative imports, but in production, it does not enable source maps for stages preceding it by default. Since `resolve-url-loader` actually requires source maps as input, it causes production builds to fail when resolving relative imports.

In order to fix this issue, I have enabled Sass source maps in production mode by default and swapped the order of `postcss-loader` and `resolve-url-loader` so we don't also have to force PostCSS to generate source maps.

However, this approach still allows users to (silently) override these settings, which might cause confusing situations. I would suggest always setting `sourceMap: true` for `sass-loader` and applying the user-specified `sourceMap` setting to `resolve-url-loader` instead.