### PR TITLE
fix: prevent emiting files in server-side

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -182,7 +182,7 @@ module.exports = (
           loader: require.resolve('file-loader'),
           options: {
             name: 'static/media/[name].[hash:8].[ext]',
-            emitFile: true,
+            emitFile: IS_WEB,
           },
         },
         // "url" loader works like "file" loader except that it embeds assets
@@ -194,7 +194,7 @@ module.exports = (
           options: {
             limit: 10000,
             name: 'static/media/[name].[hash:8].[ext]',
-            emitFile: true,
+            emitFile: IS_WEB,
           },
         },
 


### PR DESCRIPTION
```bash
➜  with-koa git:(emit) ✗ tree build
build
├── assets.json
├── public
│   ├── favicon.ico
│   ├── robots.txt
│   └── static
│       ├── css
│       │   ├── bundle.a7ebf16b.css
│       │   └── bundle.a7ebf16b.css.map
│       ├── js
│       │   ├── bundle.f8d00062.js
│       │   └── bundle.f8d00062.js.map
│       └── media
│           ├── foo.b82aa70e.ico
│           └── foo.fdcdfbcf.jpg
├── server.js
├── server.js.map
└── static # <--- duplicate
    └── media
        ├── foo.b82aa70e.ico
        └── foo.fdcdfbcf.jpg
```