### PR TITLE
fix: remove invalid option for `MiniCssExtractPlugin`

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -497,14 +497,10 @@ module.exports = (
         ...config.plugins,
         // Define production environment vars
         new webpack.DefinePlugin(dotenv.stringified),
-        // Extract our CSS into a files.
+        // Extract our CSS into files.
         new MiniCssExtractPlugin({
           filename: 'static/css/bundle.[contenthash:8].css',
           chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
-          // allChunks: true because we want all css to be included in the main
-          // css bundle when doing code splitting to avoid FOUC:
-          // https://github.com/facebook/create-react-app/issues/2415
-          allChunks: true,
         }),
         new webpack.HashedModuleIdsPlugin(),
         new webpack.optimize.AggressiveMergingPlugin(),


### PR DESCRIPTION
It's an option from `extract-text-webpack-plugin`

https://github.com/webpack-contrib/mini-css-extract-plugin/search?q=allChunks