### PR TITLE
Add moduleDirectories jest parameter

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -30,6 +30,7 @@ module.exports = (resolve, rootDir) => {
       ),
     },
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
+    moduleDirectories: ["node_modules"],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },
@@ -44,6 +45,7 @@ module.exports = (resolve, rootDir) => {
     'coverageThreshold',
     'globals',
     'mapCoverage',
+    'moduleDirectories',
     'moduleFileExtensions',
     'moduleNameMapper',
     'modulePaths',


### PR DESCRIPTION
I had the use-case of including compiled purescript output (in the `output` dir) in order to run tests. Meaning I had the the need to set moduleDirectories to `["node_modules", "output"]` in order to use razzle commands.

Support moduleDirectories jest configuration parameter for including compiled-to-js output in test run.