### PR TITLE
remove extra Razzle filter from with-react-native-web

### DIFF
--- a/examples/with-react-native-web/razzle.config.js
+++ b/examples/with-react-native-web/razzle.config.js
@@ -17,9 +17,6 @@ module.exports = {
           )
       );
 
-    const extPlugin = require(require.resolve('extract-text-webpack-plugin'));
-    config.plugins = config.plugins.filter(w => !(w instanceof extPlugin));
-
     return config;
   },
 };


### PR DESCRIPTION
Example seems to work without it if I would use Yarn (there seems to be an issue with using `npm start`).