### PR TITLE
Migrate create-razzle-app react-router-dom import

### DIFF
--- a/packages/create-razzle-app/templates/default/src/App.js
+++ b/packages/create-razzle-app/templates/default/src/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import Route from 'react-router-dom/Route';
-import Switch from 'react-router-dom/Switch';
+import { Route, Switch } from 'react-router-dom';
 import Home from './Home';
 import './App.css';
 

--- a/packages/create-razzle-app/templates/default/src/App.test.js
+++ b/packages/create-razzle-app/templates/default/src/App.test.js
@@ -1,7 +1,7 @@
 import App from './App';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import MemoryRouter from 'react-router-dom/MemoryRouter';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('<App />', () => {
   test('renders without exploding', () => {

--- a/packages/create-razzle-app/templates/default/src/client.js
+++ b/packages/create-razzle-app/templates/default/src/client.js
@@ -1,5 +1,5 @@
 import App from './App';
-import BrowserRouter from 'react-router-dom/BrowserRouter';
+import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
 import { hydrate } from 'react-dom';
 


### PR DESCRIPTION
Fix these warnings from react-router-dom:

- Warning: Please use `require("react-router-dom").Route` instead of `require("react-router-dom/Route")`. Support for the latter will be removed in the next major release.

- Warning: Please use `require("react-router-dom").Switch` instead of `require("react-router-dom/Switch")`. Support for the latter will be removed in the next major release.