### PR TITLE
allow jest watchPlugins option

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -54,6 +54,7 @@ module.exports = (resolve, rootDir) => {
     'testResultsProcessor',
     'transform',
     'transformIgnorePatterns',
+    'watchPlugins',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
with this enabled we can use awsome [`jest-watch-typeahead`](https://github.com/jest-community/jest-watch-typeahead) easily.