### PR TITLE
allow jest watchPlugins option

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -58,6 +58,7 @@ module.exports = (resolve, rootDir) => {
     'transform',
     'transformIgnorePatterns',
     'reporters',
+    'watchPlugins',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
with this enabled we can use awsome [`jest-watch-typeahead`](https://github.com/jest-community/jest-watch-typeahead) easily.