### PR TITLE
add sass-resources-loader plugin

### DIFF
--- a/packages/razzle-plugin-scss/README.md
+++ b/packages/razzle-plugin-scss/README.md
@@ -103,6 +103,20 @@ See [node-sass options](https://github.com/sass/node-sass#options) to override c
 
 ---
 
+### sassResources: _object_
+
+default
+
+```js
+{
+  resources: []
+}
+```
+
+See [sass-resources options](https://github.com/shakacode/sass-resources-loader#tips) to override configs.
+
+---
+
 ### css: _object_
 
 default

--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -51,6 +51,9 @@ const defaultOptions = {
     dev: {},
     prod: {},
   },
+  sassResources: {
+    resources: [],
+  },
 };
 
 module.exports = (
@@ -93,6 +96,25 @@ module.exports = (
     options: options.sass[constantEnv],
   };
 
+  const sassResourcesLoader = {
+    loader: require.resolve('sass-resources-loader'),
+    options: options.sassResources,
+  };
+
+  const webLoaders = [
+    dev ? styleLoader : MiniCssExtractPlugin.loader,
+    cssLoader,
+    resolveUrlLoader,
+    postCssLoader,
+    sassLoader,
+  ];
+
+  const CanAddSassResourcesLoader = !options.sassResources.resources.length;
+
+  if (CanAddSassResourcesLoader) {
+    webLoaders.push(sassResourcesLoader);
+  }
+
   config.module.rules = [
     ...config.module.rules,
     {
@@ -104,13 +126,7 @@ module.exports = (
               options: options.css[constantEnv],
             },
           ]
-        : [
-            dev ? styleLoader : MiniCssExtractPlugin.loader,
-            cssLoader,
-            resolveUrlLoader,
-            postCssLoader,
-            sassLoader,
-          ],
+        : webLoaders,
     },
   ];
 

--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -14,9 +14,10 @@
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass-chokidar": "^1.3.0",
     "postcss-flexbugs-fixes": "^3.3.1",
+    "postcss-scss": "^1.0.5",
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "^7.0.3",
-    "postcss-scss": "^1.0.5"
+    "sass-resources-loader": "^2.0.0"
   },
   "devDependencies": {
     "jest": "^23.1.0",


### PR DESCRIPTION
I added some codes in scss-plugin to make life easier. It lets importing .scss files directly into react components and load mixins and variables inside the plugin. This helps us to achieve code splitting with scss files.

before this, our folder structure was this:
- styles
    - mixins.scss
    - variables.scss
    - main.scss
- components
    - a
      - _a.scss
      - a.js
   - b
      - _b.scss
      - b.js
app.tsx

and main.scss contained:
```scss
@import "variables";
@import "mixins";
@import "../components/a/a";
@import "../components/b/b";
```
 
As you can see main.scss contains code for both a and b. if we don't load "b" component for the current route we just send unusable CSS code for user.

But after using my changes there is no need to the file main.scss, it is enough to import our mixins, variables into the config and load each scss file into the components. When the component is used, the styles get merged by MiniCSSExtractorPlugin.