### PR TITLE
document CLIENT_PUBLIC_PATH better

### DIFF
--- a/packages/razzle/README.md
+++ b/packages/razzle/README.md
@@ -6,12 +6,12 @@ Universal JavaScript applications are tough to setup. Either you buy into a fram
 
 **Razzle comes with the "battery-pack included"**:
 
-* :fire: Universal Hot Module Replacement, so both the client and server update whenever you make edits. No annoying restarts necessary
-* Comes with your favorite ES6 JavaScript goodies (through `babel-preset-razzle`)
-* Comes with the same CSS setup as [create-react-app](https://github.com/facebookincubator/create-react-app)
-* Works with [React](https://github.com/facebook/react), [Preact](https://github.com/developit/preact), [Elm](http://elm-lang.org/), [Reason-React](https://github.com/jaredpalmer/razzle/tree/master/examples/with-reason-react), [Inferno](https://github.com/infernojs), and [Rax](https://github.com/alibaba/rax) as well as [Angular](https://github.com/angular/angular) and [Vue](https://github.com/vuejs/vue) if that's your thing
-* Escape hatches for customization via `.babelrc` and `razzle.config.js`
-* [Jest](https://github.com/facebook/jest) test runner setup with sensible defaults via `razzle test`
+- :fire: Universal Hot Module Replacement, so both the client and server update whenever you make edits. No annoying restarts necessary
+- Comes with your favorite ES6 JavaScript goodies (through `babel-preset-razzle`)
+- Comes with the same CSS setup as [create-react-app](https://github.com/facebookincubator/create-react-app)
+- Works with [React](https://github.com/facebook/react), [Preact](https://github.com/developit/preact), [Elm](http://elm-lang.org/), [Reason-React](https://github.com/jaredpalmer/razzle/tree/master/examples/with-reason-react), [Inferno](https://github.com/infernojs), and [Rax](https://github.com/alibaba/rax) as well as [Angular](https://github.com/angular/angular) and [Vue](https://github.com/vuejs/vue) if that's your thing
+- Escape hatches for customization via `.babelrc` and `razzle.config.js`
+- [Jest](https://github.com/facebook/jest) test runner setup with sensible defaults via `razzle test`
 
 ## Quick Start
 
@@ -102,7 +102,7 @@ If your application is running, and you need to manually restart your server, yo
     - [What other `.env` files are can be used?](#what-other-env-files-are-can-be-used)
 - [How Razzle works (the secret sauce)](#how-razzle-works-the-secret-sauce)
 - [Inspiration](#inspiration)
-    - [Author](#author)
+  - [Author](#author)
 - [Contributors](#contributors)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -113,11 +113,11 @@ If your application is running, and you need to manually restart your server, yo
 
 As of Razzle 2.0, you can add your plugins to modify your setup.
 
-* [TypeScript](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-typescript)
-* [Vue](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-vue)
-* [Elm](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-elm)
-* [MDX](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-mdx)
-* [See All](https://www.npmjs.com/search?q=razzle-plugin)
+- [TypeScript](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-typescript)
+- [Vue](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-vue)
+- [Elm](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-elm)
+- [MDX](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-mdx)
+- [See All](https://www.npmjs.com/search?q=razzle-plugin)
 
 #### Using Plugins
 
@@ -130,7 +130,7 @@ yarn add razzle-plugin-xxxx
 ```js
 //./razzle.config.js
 module.exports = {
-  plugins: ['xxxx'],
+  plugins: ['xxxx']
 };
 ```
 
@@ -193,7 +193,7 @@ module.exports = {
     // do something to config
 
     return config;
-  },
+  }
 };
 ```
 
@@ -229,15 +229,16 @@ export default Component;
 
 **The following environment variables are embedded during the build time.**
 
-* `process.env.RAZZLE_PUBLIC_DIR`: Path to the public directory.
-* `process.env.RAZZLE_ASSETS_MANIFEST`: Path to a file containing compiled asset outputs
-* `process.env.REACT_BUNDLE_PATH`: Relative path to where React will be bundled during development. Unless you are modifying the output path of your webpack config, you can safely ignore this. This path is used by `react-error-overlay` and webpack to power up the fancy runtime error iframe. For example, if you are using common chunks and an extra entry to create a vendor bundle with stuff like react, react-dom, react-router, etc. called `vendor.js`, and you've changed webpack's output to `[name].js` in development, you'd want to set this environment variable to `/static/js/vendor.js`. If you do not make this change, nothing bad will happen, you will simply not get the cool error overlay when there are runtime errors. You'll just see them in the console. Note: This does not impact production bundling.
-* `process.env.VERBOSE`: default is false, setting this to true will not clear the console when you make edits in development (useful for debugging).
-* `process.env.PORT`: default is `3000`, unless changed
-* `process.env.HOST`: default is `0.0.0.0`
-* `process.env.NODE_ENV`: `'development'` or `'production'`
-* `process.env.BUILD_TARGET`: either `'client'` or `'server'`
-* `process.env.PUBLIC_PATH`: Only in used in `razzle build`. You can alter the `webpack.config.output.publicPath` of the client assets (bundle, css, and images). This is useful if you plan to serve your assets from a CDN. Make sure to _include_ a trailing slash (e.g. `PUBLIC_PATH=https://cdn.example.com/`). If you are using React and altering the public path, make sure to also [include the `crossorigin` attribute](https://reactjs.org/docs/cdn-links.html#why-the-crossorigin-attribute) on your `<script>` tag in `src/server.js`.
+- `process.env.RAZZLE_PUBLIC_DIR`: Path to the public directory.
+- `process.env.RAZZLE_ASSETS_MANIFEST`: Path to a file containing compiled asset outputs
+- `process.env.REACT_BUNDLE_PATH`: Relative path to where React will be bundled during development. Unless you are modifying the output path of your webpack config, you can safely ignore this. This path is used by `react-error-overlay` and webpack to power up the fancy runtime error iframe. For example, if you are using common chunks and an extra entry to create a vendor bundle with stuff like react, react-dom, react-router, etc. called `vendor.js`, and you've changed webpack's output to `[name].js` in development, you'd want to set this environment variable to `/static/js/vendor.js`. If you do not make this change, nothing bad will happen, you will simply not get the cool error overlay when there are runtime errors. You'll just see them in the console. Note: This does not impact production bundling.
+- `process.env.VERBOSE`: default is false, setting this to true will not clear the console when you make edits in development (useful for debugging).
+- `process.env.PORT`: default is `3000`, unless changed
+- `process.env.HOST`: default is `0.0.0.0`
+- `process.env.NODE_ENV`: `'development'` or `'production'`
+- `process.env.BUILD_TARGET`: either `'client'` or `'server'`
+- `process.env.PUBLIC_PATH`: Only in used in `razzle build`. You can alter the `webpack.config.output.publicPath` of the client assets (bundle, css, and images). This is useful if you plan to serve your assets from a CDN. Make sure to _include_ a trailing slash (e.g. `PUBLIC_PATH=https://cdn.example.com/`). If you are using React and altering the public path, make sure to also [include the `crossorigin` attribute](https://reactjs.org/docs/cdn-links.html#why-the-crossorigin-attribute) on your `<script>` tag in `src/server.js`.
+- `process.env.CLIENT_PUBLIC_PATH`: The NODE_ENV=development build's BUILD_TARGET=client has a different PUBLIC_PATH than BUILD_TARGET=server. Default is `http://${process.env.HOST}:${process.env.PORT + 1}/`. If you run your development environment on a specific url (e.g. process.env.HOST=10.1.2.3), you can set this to `http://10.1.2.3:3001/`.
 
 You can create your own custom build-time environment variables. They must start
 with `RAZZLE_`. Any other variables except the ones listed above will be ignored to avoid accidentally exposing a private key on the machine that could have the same name. Changing any environment variables will require you to restart the development server if it is running.
@@ -255,12 +256,12 @@ export const runtimeConfig =
     ? {
         // client
         myThing: window.env.myThing,
-        anotherThing: window.env.anotherThing,
+        anotherThing: window.env.anotherThing
       }
     : {
         // server
         myThing: process.env.MY_THING,
-        anotherThing: process.env.ANOTHER_THING,
+        anotherThing: process.env.ANOTHER_THING
       };
 ```
 
@@ -338,16 +339,16 @@ RAZZLE_SECRET_CODE=abcdef
 
 #### What other `.env` files are can be used?
 
-* `.env`: Default.
-* `.env.local`: Local overrides. **This file is loaded for all environments except test.**
-* `.env.development`, `.env.test`, `.env.production`: Environment-specific settings.
-* `.env.development.local`, `.env.test.local`, `.env.production.local`: Local overrides of environment-specific settings.
+- `.env`: Default.
+- `.env.local`: Local overrides. **This file is loaded for all environments except test.**
+- `.env.development`, `.env.test`, `.env.production`: Environment-specific settings.
+- `.env.development.local`, `.env.test.local`, `.env.production.local`: Local overrides of environment-specific settings.
 
 Files on the left have more priority than files on the right:
 
-* `npm start`: `.env.development.local`, `.env.development`, `.env.local`, `.env`
-* `npm run build`: `.env.production.local`, `.env.production`, `.env.local`, `.env`
-* `npm test`: `.env.test.local`, `.env.test`, `.env` (note `.env.local` is missing)
+- `npm start`: `.env.development.local`, `.env.development`, `.env.local`, `.env`
+- `npm run build`: `.env.production.local`, `.env.production`, `.env.local`, `.env`
+- `npm test`: `.env.test.local`, `.env.test`, `.env` (note `.env.local` is missing)
 
 These variables will act as the defaults if the machine does not explicitly set them.<br>
 Please refer to the [dotenv documentation](https://github.com/motdotla/dotenv) for more details.
@@ -363,15 +364,15 @@ In development mode (`razzle start`), Razzle bundles both your client and server
 
 ## Inspiration
 
-* [palmerhq/backpack](https://github.com/palmerhq/backpack)
-* [nytimes/kyt](https://github.com/nytimes/kyt)
-* [facebookincubator/create-react-app](https://github.com/facebookincubator/create-react-app)
-* [humblespark/sambell](https://github.com/humblespark/sambell)
-* [zeit/next.js](https://github.com/zeit/next.js)
+- [palmerhq/backpack](https://github.com/palmerhq/backpack)
+- [nytimes/kyt](https://github.com/nytimes/kyt)
+- [facebookincubator/create-react-app](https://github.com/facebookincubator/create-react-app)
+- [humblespark/sambell](https://github.com/humblespark/sambell)
+- [zeit/next.js](https://github.com/zeit/next.js)
 
 #### Author
 
-* [Jared Palmer](https://twitter.com/jaredpalmer)
+- [Jared Palmer](https://twitter.com/jaredpalmer)
 
 ---
 


### PR DESCRIPTION
The master doesn't have documentation for `CLIENT_PUBLIC_PATH`, even though I did find it in a specific commit. I used that documentation and added an aspect that is relevant if you run your development on a specific ip address (not localhost). Namely that you need to specify CLIENT_PUBLIC_PATH explicitly to be able to run.

I also found a bug, which I didn't fix. Which is that if you don't add a trailing slash to your CLIENT_PUBLIC_PATH, any async loaded js will bomb, because it misses that slash.