### PR TITLE
expose config logic and generalize web target to support electron

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -68,7 +68,8 @@ module.exports = (
 
   // Define some useful shorthands.
   const IS_NODE = target === 'node';
-  const IS_WEB = target === 'web';
+  const IS_ELECTRON = target.indexOf('electron') > -1;
+  const IS_CLIENT = target === 'web' || IS_ELECTRON;
   const IS_PROD = env === 'prod';
   const IS_DEV = env === 'dev';
   process.env.NODE_ENV = IS_PROD ? 'production' : 'development';
@@ -150,7 +151,7 @@ module.exports = (
           loader: require.resolve('file-loader'),
           options: {
             name: 'static/media/[name].[hash:8].[ext]',
-            emitFile: IS_WEB,
+            emitFile: IS_CLIENT,
           },
         },
         // "url" loader works like "file" loader except that it embeds assets
@@ -162,7 +163,7 @@ module.exports = (
           options: {
             limit: 10000,
             name: 'static/media/[name].[hash:8].[ext]',
-            emitFile: IS_WEB,
+            emitFile: IS_CLIENT,
           },
         },
 
@@ -344,7 +345,7 @@ module.exports = (
     }
   }
 
-  if (IS_WEB) {
+  if (IS_CLIENT) {
     config.plugins = [
       // Output our JS and CSS files in a manifest file called assets.json
       // in the build directory.
@@ -418,7 +419,7 @@ module.exports = (
       config.plugins = [
         ...config.plugins,
         new webpack.HotModuleReplacementPlugin({
-          multiStep: true,
+          multiStep: !IS_ELECTRON,
         }),
         new webpack.DefinePlugin(dotenv.stringified),
       ];

--- a/packages/razzle/lib/index.js
+++ b/packages/razzle/lib/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../config/env');
+
+const paths = require('../config/paths');
+const createConfig = require('../config/createConfig');
+const { getRazzleConfig, compile } = require('./utils');
+
+module.exports = {
+  paths,
+  createConfig,
+  getRazzleConfig,
+  compile,
+};

--- a/packages/razzle/lib/utils.js
+++ b/packages/razzle/lib/utils.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const fs = require('fs-extra');
+const webpack = require('webpack');
+const paths = require('../config/paths');
+const printErrors = require('razzle-dev-utils/printErrors');
+const clearConsole = require('react-dev-utils/clearConsole');
+const logger = require('razzle-dev-utils/logger');
+
+exports.getRazzleConfig = function getRazzleConfig(env) {
+  let razzle = {};
+  if (fs.existsSync(paths.appRazzleConfig)) {
+    try {
+      razzle = require(paths.appRazzleConfig);
+    } catch (e) {
+      if (env === 'dev') {
+        clearConsole();
+        logger.error('Invalid razzle.config.js file.', e);
+        process.exit(1);
+      }
+    }
+  }
+  return razzle;
+};
+
+exports.compile = function compile(webpackConfig) {
+  let compiler;
+  try {
+    compiler = webpack(webpackConfig);
+  } catch (e) {
+    printErrors('Failed to compile.', [e]);
+    process.exit(1);
+  }
+  return compiler;
+};

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -8,6 +8,7 @@
   "bin": {
     "razzle": "./bin/razzle.js"
   },
+  "main": "lib/index.js",
   "files": [
     "bin",
     "config",

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -4,11 +4,8 @@
 process.env.NODE_ENV = 'development';
 const fs = require('fs-extra');
 const webpack = require('webpack');
-const paths = require('../config/paths');
-const createConfig = require('../config/createConfig');
+const { paths, createConfig, getRazzleConfig, compile } = require('../lib');
 const devServer = require('webpack-dev-server');
-const printErrors = require('razzle-dev-utils/printErrors');
-const clearConsole = require('react-dev-utils/clearConsole');
 const logger = require('razzle-dev-utils/logger');
 const setPorts = require('razzle-dev-utils/setPorts');
 
@@ -26,19 +23,7 @@ function main() {
   // FriendlyErrorsPlugin during compilation, so the user has immediate feedback.
   // clearConsole();
   logger.start('Compiling...');
-  let razzle = {};
-
-  // Check for razzle.config.js file
-  if (fs.existsSync(paths.appRazzleConfig)) {
-    try {
-      razzle = require(paths.appRazzleConfig);
-    } catch (e) {
-      clearConsole();
-      logger.error('Invalid razzle.config.js file.', e);
-      process.exit(1);
-    }
-  }
-
+  const razzle = getRazzleConfig('dev');
   // Delete assets.json to always have a manifest up to date
   fs.removeSync(paths.appManifest);
 
@@ -84,18 +69,6 @@ function main() {
       }
     }
   );
-}
-
-// Webpack compile in a try-catch
-function compile(config) {
-  let compiler;
-  try {
-    compiler = webpack(config);
-  } catch (e) {
-    printErrors('Failed to compile.', [e]);
-    process.exit(1);
-  }
-  return compiler;
 }
 
 setPorts()


### PR DESCRIPTION
works on #1019

since webpack supports electron as a target, would be great if razzle added support for it as well

this PR exposes the config logic, so we can create custom start script for electron that only runs client bundle (the only issue I ran into was that `multiStep` option was causing errors, which is why I generalized the target client env to fix this, so now we have `IS_CLIENT` and `IS_ELECTRON` checks)

a custom electron `script` can also be added in another PR to make setup even easier, or it can be shown as an `example`

