### PR TITLE
use onlyLocals option instead of css-loader/locals

### DIFF
--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -103,8 +103,8 @@ module.exports = (
       use: isServer
         ? [
             {
-              loader: require.resolve('css-loader/locals'),
-              options: options.css[constantEnv],
+              loader: require.resolve('css-loader'),
+              options: Object.assign({}, options.css[constantEnv], {onlyLocals: true}),
             },
             resolveUrlLoader,
             postCssLoader,


### PR DESCRIPTION
`css-loader/locals` is no longer available in favor of the new `onlyLocals` options.