### PR TITLE
Load .js files before .jsx files

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -98,7 +98,7 @@ module.exports = (
         // It is guaranteed to exist because we tweak it in `env.js`
         nodePath.split(path.delimiter).filter(Boolean)
       ),
-      extensions: ['.mjs', '.jsx', '.js', '.json'],
+      extensions: ['.mjs', '.js', '.jsx', '.json'],
       alias: {
         // This is required so symlinks work during development.
         'webpack/hot/poll': require.resolve('webpack/hot/poll'),


### PR DESCRIPTION
Create React App specifies that .js extensions take precedence over .jsx files when `import`ing. `moduleFileExtensions` is [defined here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/paths.js#L49) and then used to [define `resolve.extensions` in webpage.config here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.js#L282).

The result of this is that if you have both an index.js file and an index.jsx for a given component, index.js can be imported by simply `import ../components/MyComponent`, and index.jsx must be imported by `import ../components/MyComponent/index.jsx` - as opposed to the other way around.