### PR TITLE
ReactNativeWeb Example: Move script to bottom of Body

### DIFF
--- a/examples/with-react-native-web/src/server.js
+++ b/examples/with-react-native-web/src/server.js
@@ -31,14 +31,15 @@ server
         <title>Welcome to Razzle</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         ${css}
-        ${
+      
+    </head>
+    <body>
+        <div id="root">${html}</div>
+  ${
           process.env.NODE_ENV === 'production'
             ? `<script src="${assets.client.js}" defer></script>`
             : `<script src="${assets.client.js}" defer crossorigin></script>`
         }
-    </head>
-    <body>
-        <div id="root">${html}</div>
     </body>
 </html>`
     );


### PR DESCRIPTION
I'm pretty sure it's considered best practice BUT even more importantly, you can hit a situation where the script loads before the div root tag is added to the DOM resulting in a hard to debug:

"Invariant Exception: Expect to have a valid rootTag, instead got...."