### PR TITLE
Fix type error on express.listen()

### DIFF
--- a/examples/with-typescript/src/index.ts
+++ b/examples/with-typescript/src/index.ts
@@ -16,7 +16,7 @@ if (module.hot) {
   console.info('✅  Server-side HMR Enabled!');
 }
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
 export default express()
   .use((req, res) => app.handle(req, res))


### PR DESCRIPTION
I created an razzle app with `--example with-typescript`, built the app right after creation, and failed to build.

`const port = process.env.PORT || 3000;` makes type of `port` to be `string | 3000`.

`express.listen()` has several signatures, two of which are `listen(port: number, callback?: (...args: any[]) => void): http.Server;` and `listen(handle: any, listeningListener?: () => void): http.Server;`.

I think `port` should be of `number` type, and `express.listen()`should be inferred with the former signature.

But, for now, `port` is of an undesirable type and it gives an error which says that its arguments does not fit with the latter signature.