### PR TITLE
Add support for variable expansion in .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,26 @@ To define permanent environment variables, create a file called .env in the root
 RAZZLE_SECRET_CODE=abcdef
 ```
 
+### Expanding Environment Variables In `.env`
+
+Expand variables already on your machine for use in your `.env` file.
+
+For example, to get the environment variable `npm_package_version`:
+
+```
+RAZZLE_VERSION=$npm_package_version
+# also works:
+# RAZZLE_VERSION=${npm_package_version}
+```
+
+Or expand variables local to the current `.env` file:
+
+```
+DOMAIN=www.example.com
+RAZZLE_FOO=$DOMAIN/foo
+RAZZLE_BAR=$DOMAIN/bar
+```
+
 #### What other `.env` files are can be used?
 
 - `.env`: Default.

--- a/packages/razzle/config/env.js
+++ b/packages/razzle/config/env.js
@@ -23,13 +23,16 @@ var dotenvFiles = [
 ];
 // Load environment variables from .env* files. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
-// that have already been set.
+// that have already been set. Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
+// https://github.com/motdotla/dotenv-expand
 dotenvFiles.forEach(dotenvFile => {
   if (fs.existsSync(dotenvFile)) {
-    require('dotenv').config({
-      path: dotenvFile,
-    });
+    require('dotenv-expand')(
+      require('dotenv').config({
+        path: dotenvFile,
+      })
+    );
   }
 });
 

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -37,6 +37,7 @@
     "chalk": "^2.4.1",
     "css-loader": "^1.0.0",
     "dotenv": "6.0.0",
+    "dotenv-expand": "4.2.0",
     "file-loader": "^3.0.1",
     "fs-extra": "7.0.0",
     "jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,6 +5673,11 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-expand@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275"
+  integrity sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=
+
 dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"


### PR DESCRIPTION
Added [dotenv-expand](https://github.com/motdotla/dotenv-expand) so that variables can be expanded in .env files.