### PR TITLE
Fixes the heroku example

### DIFF
--- a/examples/with-heroku/package.json
+++ b/examples/with-heroku/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "express": "^4.15.2",
     "razzle": "^3.0.0",
+    "razzle-heroku": "^3.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   }

--- a/examples/with-heroku/razzle.config.js
+++ b/examples/with-heroku/razzle.config.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const razzleHeroku = require('razzle-heroku');
+
+module.exports = {
+  modify(config, { target, dev }, webpack) {
+    config = razzleHeroku(config, {target, dev}, webpack);
+
+    return config;
+  },
+};


### PR DESCRIPTION
I believe this `razzle-heroku` plugin is needed for the example/with-heroku to actually work on heroku. 
Without the plugin, heroku throws an error that it can’t find the port. 
See https://github.com/jaredpalmer/razzle/issues/340
