### PR TITLE
update http server to use event instead of callback param for error h…

### DIFF
--- a/packages/create-razzle-app/templates/default/src/index.js
+++ b/packages/create-razzle-app/templates/default/src/index.js
@@ -6,13 +6,13 @@ const server = http.createServer(app);
 
 let currentApp = app;
 
-server.listen(process.env.PORT || 3000, error => {
-  if (error) {
+server
+  .listen(process.env.PORT || 3000, () => {
+    console.log('🚀 started');
+  })
+  .on('error', error => {
     console.log(error);
-  }
-
-  console.log('🚀 started');
-});
+  });
 
 if (module.hot) {
   console.log('✅  Server-side HMR Enabled!');


### PR DESCRIPTION
got a typescript error that handling for http server was being done via callback param (types allow no params for callback), should be using event instead.  also saw someone else ran into this issue #1077 