### PR TITLE
Remove razzle/polyfill from with-vendor-bundle example

### DIFF
--- a/examples/with-vendor-bundle/razzle.config.js
+++ b/examples/with-vendor-bundle/razzle.config.js
@@ -13,11 +13,6 @@ module.exports = {
 
       // add another entry point called vendor
       config.entry.vendor = [
-        // now that React has moved, we need to Razzle's polyfills because
-        // vendor.js will be loaded before our other entry. Razzle looks for
-        // process.env.REACT_BUNDLE_PATH and will exclude the polyfill from our normal entry,
-        // so we don't need to worry about including it twice.
-        require.resolve('razzle/polyfills'),
         require.resolve('react'),
         require.resolve('react-dom'),
         // ... add any other vendor packages with require.resolve('xxx')


### PR DESCRIPTION
...because it no longer resolves, and `require.resolve()`ing it will throw an Error when requiring razzle.config.js and lead to very confusing `razzle build` error