### PR TITLE
moduleResolution intent is "Node" not "node" per doc

### DIFF
--- a/examples/with-typescript/tsconfig.json
+++ b/examples/with-typescript/tsconfig.json
@@ -10,7 +10,7 @@
     "jsx": "react",
     "lib": ["es6", "es2015", "es2017", "dom"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
In https://www.typescriptlang.org/docs/handbook/compiler-options.html is says default for `--moduleResolution` is `module === "AMD" or "System" or "ES6" ? "Classic" : "Node"`

In current tsconfig.json, it is lower cased "node".  Don't think this causes any unintended side effect right now but would be nice if we could be deliberate on setting it to "Node" in case.  Also, in typescript repo `protocol.d.ts` says 
`const enum ModuleResolutionKind {
      Classic = "Classic",
      Node = "Node"
  }`