### PR TITLE
fix flash of unstyled content (FOUC)

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -457,8 +457,7 @@ module.exports = (
         new webpack.DefinePlugin(dotenv.stringified),
         // Extract our CSS into a files.
         new MiniCssExtractPlugin({
-          filename: 'static/css/bundle.[contenthash:8].css',
-          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
+          filename: 'static/css/[name].[contenthash:8].css',
         }),
         new webpack.HashedModuleIdsPlugin(),
         new webpack.optimize.AggressiveMergingPlugin(),
@@ -470,8 +469,8 @@ module.exports = (
         splitChunks: {
           cacheGroups: {
             styles: {
-              name: 'styles',
-              test: /\.(css|scss|sass|sss|less)$/,
+              name: 'bundle',
+              test: /\.css$/,
               chunks: 'all',
               enforce: true,
             },

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -459,16 +459,24 @@ module.exports = (
         new MiniCssExtractPlugin({
           filename: 'static/css/bundle.[contenthash:8].css',
           chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
-          // allChunks: true because we want all css to be included in the main
-          // css bundle when doing code splitting to avoid FOUC:
-          // https://github.com/facebook/create-react-app/issues/2415
-          allChunks: true,
         }),
         new webpack.HashedModuleIdsPlugin(),
         new webpack.optimize.AggressiveMergingPlugin(),
       ];
 
       config.optimization = {
+        // because we want all css to be included in the main
+        // css bundle when doing code splitting to avoid FOUC
+        splitChunks: {
+          cacheGroups: {
+            styles: {
+              name: 'styles',
+              test: /\.(css|scss|sass|sss|less)$/,
+              chunks: 'all',
+              enforce: true,
+            },
+          },
+        },
         minimize: true,
         minimizer: [
           new TerserPlugin({

--- a/test/tests/razzle-build.test.js
+++ b/test/tests/razzle-build.test.js
@@ -38,7 +38,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });
@@ -67,7 +67,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });
@@ -93,7 +93,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });

--- a/test/tests/razzle-build.test.js
+++ b/test/tests/razzle-build.test.js
@@ -38,7 +38,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });
@@ -67,7 +67,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });
@@ -93,7 +93,7 @@ describe('razzle build', () => {
 
     // should compile client css to css directory
     expect(shell.test('-d', 'build/public/static/css')).toBeTruthy();
-    expect(shell.ls('build/public/static/css/bundle.*.css').code).toBe(0);
+    expect(shell.ls('build/public/static/css/styles.*.css').code).toBe(0);
 
     expect(output.code).toBe(0);
   });


### PR DESCRIPTION
I was reading comments of `createConfig.js` and then I noticed this:

```javascript
// Extract our CSS into a files.
new MiniCssExtractPlugin({
  filename: 'static/css/bundle.[contenthash:8].css',
  chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
  // allChunks: true because we want all css to be included in the main
  // css bundle when doing code splitting to avoid FOUC:
  // https://github.com/facebook/create-react-app/issues/2415
  allChunks: true,
}),
```

`allChunks: true` means don't split CSS files, just put all in one file. but it's not working because there is no such a config in `MiniCssExtractPlugin`! based on MiniCssExtractPlugin [documentation](https://webpack.js.org/plugins/mini-css-extract-plugin/#extracting-all-css-in-a-single-file) we have to change `cacheGroups` in webpack config so I've changed it.

## Before merging this PR, think about config

```javascript
splitChunks: {
  cacheGroups: {
    styles: {
      name: 'bundle',
      test: /\.css$/,
      chunks: 'all',
      enforce: true,
    },
  },
},
```

this config only works with `.css` files, but what if we want to merge other files (sass or less) into `bundle.css` file?
to add support for them we can do
```javascript
test: /\.(css|scss|sass|less|styl)$/,
```
or we can ignore this, and add file extensions on plugins (like `razzle-plugin-scss`).
I think we have to do both, maybe someone updates razzle but don't update that plugin or Vice Versa