### PR TITLE
Pass environment information to modifyBabelOptions

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -44,6 +44,13 @@ module.exports = (
   },
   webpackObject
 ) => {
+  // Define some useful shorthands.
+  const IS_NODE = target === 'node';
+  const IS_WEB = target === 'web';
+  const IS_PROD = env === 'prod';
+  const IS_DEV = env === 'dev';
+  process.env.NODE_ENV = IS_PROD ? 'production' : 'development';
+
   // First we check to see if the user has a custom .babelrc file, otherwise
   // we just use babel-preset-razzle.
   const hasBabelRc = fs.existsSync(paths.appBabelRc);
@@ -59,7 +66,7 @@ module.exports = (
 
   // Allow app to override babel options
   const babelOptions = modifyBabelOptions
-    ? modifyBabelOptions(mainBabelOptions)
+    ? modifyBabelOptions(mainBabelOptions, { target, dev: IS_DEV })
     : mainBabelOptions;
 
   if (hasBabelRc && babelOptions.babelrc) {

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -73,13 +73,6 @@ module.exports = (
     console.log('Using .babelrc defined in your app root');
   }
 
-  // Define some useful shorthands.
-  const IS_NODE = target === 'node';
-  const IS_WEB = target === 'web';
-  const IS_PROD = env === 'prod';
-  const IS_DEV = env === 'dev';
-  process.env.NODE_ENV = IS_PROD ? 'production' : 'development';
-
   const dotenv = getClientEnv(target, { clearConsole, host, port });
 
   const devServerPort = parseInt(dotenv.raw.PORT, 10) + 1;


### PR DESCRIPTION
Currently deriving a per-environment babel configuration is pretty tedious, involves having to do some annoying finding and mutating on the babel loader within `modify`.

This change passes the same environment information(`target` and `dev`) to `modifyBabelOptions` as is passed to `modify`, and now modifying the config for every environment is much more convenient.