### PR TITLE
added cssModules for files *.module.scss in razzle-plugin-scss

### DIFF
--- a/packages/razzle-plugin-scss/README.md
+++ b/packages/razzle-plugin-scss/README.md
@@ -117,13 +117,13 @@ default
 {
   dev: {
     sourceMap: true,
-		includePaths: [paths.appNodeModules],
-		modules: true
+    includePaths: [paths.appNodeModules],
+    modules: true
   },
   prod: {
     sourceMap: false,
-		includePaths: [paths.appNodeModules],
-		modules: true
+    includePaths: [paths.appNodeModules],
+    modules: true
   },
 }
 ```

--- a/packages/razzle-plugin-scss/README.md
+++ b/packages/razzle-plugin-scss/README.md
@@ -17,7 +17,13 @@ module.exports = {
   plugins: ['scss'],
 };
 ```
+Files with an ending in the name *.module.scss and *.module.sass will load as cssModules
 
+example:
+
+```jsx
+import s from './myfile.module.scss'
+```
 ---
 
 ### With custom options
@@ -103,6 +109,31 @@ See [node-sass options](https://github.com/sass/node-sass#options) to override c
 
 ---
 
+### sassModules: _object_
+
+default
+
+```js
+{
+  dev: {
+    sourceMap: true,
+		includePaths: [paths.appNodeModules],
+		modules: true
+  },
+  prod: {
+    sourceMap: false,
+		includePaths: [paths.appNodeModules],
+		modules: true
+  },
+}
+```
+
+Set `dev` to add config to postcss in `development`.
+Set `prod` to add config to postcss in `production`.
+
+See [node-sass options](https://github.com/sass/node-sass#options) to override configs.
+
+---
 ### css: _object_
 
 default

--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -100,6 +100,7 @@ module.exports = (
     ...config.module.rules,
     {
       test: /\.(sa|sc)ss$/,
+      exclude: [/\.module.(sa|sc)ss$/],
       use: isServer
         ? [
             {
@@ -113,6 +114,35 @@ module.exports = (
         : [
             dev ? styleLoader : MiniCssExtractPlugin.loader,
             cssLoader,
+            postCssLoader,
+            resolveUrlLoader,
+            sassLoader,
+          ],
+    },
+    {
+      test: /\.module.(sa|sc)ss$/,
+      use: isServer
+        ? [
+            {
+              loader: require.resolve('css-loader/locals'),
+              options: Object.assign({}, options.css[constantEnv], {
+                modules: true,
+                localIdentName: '[name]__[local]___[hash:base64:5]',
+              }),
+            },
+            resolveUrlLoader,
+            postCssLoader,
+            sassLoader,
+          ]
+        : [
+            dev ? styleLoader : MiniCssExtractPlugin.loader,
+            {
+              loader: require.resolve('css-loader'),
+              options: Object.assign({}, options.css[constantEnv], {
+                modules: true,
+                localIdentName: '[name]__[local]___[hash:base64:5]',
+              }),
+            },
             postCssLoader,
             resolveUrlLoader,
             sassLoader,


### PR DESCRIPTION
Files with an ending in the name *.module.scss and *.module.sass will load as cssModules

example:

```jsx
import s from './myfile.module.scss'
```