### PR TITLE
add support for proxying the devserver

### DIFF
--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -22,7 +22,7 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
     url.format({
       protocol: window.location.protocol,
       hostname: window.location.hostname,
-      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : window.location.port, 10) + 1,
+      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : parseInt(window.location.port, 10) + 1,
       pathname: launchEditorEndpoint,
       search:
         '?fileName=' +
@@ -62,7 +62,7 @@ var connection = new SockJS(
   url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : window.location.port, 10) + 1,
+      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : parseInt(window.location.port, 10) + 1,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
   })

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -22,7 +22,7 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
     url.format({
       protocol: window.location.protocol,
       hostname: window.location.hostname,
-      port: parseInt(process.env.PORT || window.location.port, 10) + 1,
+      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : window.location.port, 10) + 1,
       pathname: launchEditorEndpoint,
       search:
         '?fileName=' +
@@ -62,7 +62,7 @@ var connection = new SockJS(
   url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-    port: parseInt(process.env.PORT || window.location.port, 10) + 1,
+      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : window.location.port, 10) + 1,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
   })

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -64,7 +64,7 @@ var connection = new SockJS(
     hostname: window.location.hostname,
       port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : parseInt(window.location.port, 10) + 1,
     // Hardcoded in WebpackDevServer
-    pathname: '/sockjs-node',
+    pathname: SOCKJS_NODE_PATH,
   })
 );
 

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -22,7 +22,7 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
     url.format({
       protocol: window.location.protocol,
       hostname: window.location.hostname,
-      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : parseInt(window.location.port, 10) + 1,
+      port: HOTDEVCLIENT_PORT,
       pathname: launchEditorEndpoint,
       search:
         '?fileName=' +
@@ -62,8 +62,7 @@ var connection = new SockJS(
   url.format({
     protocol: window.location.protocol,
     hostname: window.location.hostname,
-      port: HOTDEVCLIENT_PORT ? parseInt(HOTDEVCLIENT_PORT) : parseInt(window.location.port, 10) + 1,
-    // Hardcoded in WebpackDevServer
+    port: HOTDEVCLIENT_PORT,
     pathname: SOCKJS_NODE_PATH,
   })
 );

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -85,7 +85,7 @@ module.exports = (
   // VMs, Docker containers might be reverse proxied with SSL at example.com:443. CLIENT_PUBLIC_PATH can override.
   const {
     host: hotDevClientPublic = `${dotenv.raw.HOST}:${devServerPort}`,
-    port: hotDevClientPort = parseInt(dotenv.raw.PORT) + 1
+    port: hotDevClientPort = parseInt(dotenv.raw.PORT) + 1,
     pathname: hotDevClientPathName = '/'
   } = clientPublicPath ? url.parse(dotenv.raw.CLIENT_PUBLIC_PATH) : {};
 

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -83,10 +83,14 @@ module.exports = (
     (IS_DEV ? `http://${dotenv.raw.HOST}:${devServerPort}/` : '/');
 
   // VMs, Docker containers might be reverse proxied with SSL at example.com:443. CLIENT_PUBLIC_PATH can override.
-  const { host: hotDevClientPublic, port: hotDevClientPort } = dotenv.raw.CLIENT_PUBLIC_PATH
-    ? url.parse(dotenv.raw.CLIENT_PUBLIC_PATH)
-    : { host: `${dotenv.raw.HOST}:${devServerPort}`, port: parseInt(dotenv.raw.PORT) + 1 };
+  const {
+    host: hotDevClientPublic = `${dotenv.raw.HOST}:${devServerPort}`,
+    port: hotDevClientPort = parseInt(dotenv.raw.PORT) + 1
+    pathname: hotDevClientPathName = '/'
+  } = clientPublicPath ? url.parse(dotenv.raw.CLIENT_PUBLIC_PATH) : {};
 
+  const sockPath = `${hotDevClientPathName}/sockjs-node`;
+  
   // This is our base webpack config.
   let config = {
     // Set webpack mode:
@@ -409,6 +413,7 @@ module.exports = (
         overlay: false,
         port: devServerPort,
         public: hotDevClientPublic,
+        sockPath: sockPath,
         quiet: true,
         // By default files from `contentBase` will not trigger a page reload.
         // Reportedly, this avoids CPU overload on some systems.
@@ -429,6 +434,7 @@ module.exports = (
         }),
         new webpack.DefinePlugin({
           HOTDEVCLIENT_PORT: JSON.stringify(hotDevClientPort),
+          SOCKJS_NODE_PATH: JSON.stringify(sockPath),
           ...dotenv.stringified
         }),
       ];


### PR DESCRIPTION
Would be great to havet if you want to show your work to clients.

Currently I use replace-loader to replace the port by regular expressions.