### PR TITLE
Bump postcss-scss dependency versions

### DIFF
--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -18,7 +18,6 @@ const defaultOptions = {
     plugins: [
       PostCssFlexBugFixes,
       autoprefixer({
-        browsers: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9'],
         flexbox: 'no-2009',
       }),
     ],

--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "jest"
   },
+  "browserList":[
+    ">1%", "last 4 versions", "Firefox ESR", "not ie < 9"
+  ],
   "dependencies": {
     "autoprefixer": "^9.6.5",
     "mini-css-extract-plugin": "^0.4.0",

--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "autoprefixer": "^8.6.2",
+    "autoprefixer": "^9.6.5",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass-chokidar": "^1.3.0",
     "postcss-flexbugs-fixes": "^3.3.1",

--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -13,8 +13,8 @@
     "autoprefixer": "^9.6.5",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass-chokidar": "^1.3.0",
-    "postcss-flexbugs-fixes": "^3.3.1",
-    "postcss-scss": "^1.0.5",
+    "postcss-flexbugs-fixes": "^4.1.0",
+    "postcss-scss": "^2.0.0",
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "^7.0.3"
   },

--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest"
   },
-  "browserList":[
+  "browserslist":[
     ">1%", "last 4 versions", "Firefox ESR", "not ie < 9"
   ],
   "dependencies": {


### PR DESCRIPTION
Fixes autoprefixer issues like #1161 