### PR TITLE
Fix vue-router error + SSR 404

### DIFF
--- a/examples/with-vue-router/src/server.js
+++ b/examples/with-vue-router/src/server.js
@@ -15,7 +15,7 @@ server
     const { app, router } = createVueApp();
 
     // Set server-side router's location
-    router.push(req.url);
+    router.push(req.originalUrl).catch(err => {});
 
     // wait until the router has resolved possible async components and hooks
     router.onReady(async () => {


### PR DESCRIPTION
Fixed breaking error due to vue-router update explained here: https://github.com/vuejs/vue-router/issues/2881

Also only the 404 page was being loaded on server in `vueMarkup` – replacing `req.url` with `req.originalUrl` fixed that (not sure if this is optimal but it works for now)