### PR TITLE
Update fork-ts-cheker-webpack-plugin so that it has eslint support

### DIFF
--- a/packages/razzle-plugin-typescript/index.js
+++ b/packages/razzle-plugin-typescript/index.js
@@ -13,7 +13,6 @@ const defaultOptions = {
     tsconfig: './tsconfig.json',
     tslint: './tslint.json',
     watch: ['./src'],
-    typeCheck: true,
   },
 };
 

--- a/packages/razzle-plugin-typescript/package.json
+++ b/packages/razzle-plugin-typescript/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "fork-ts-checker-webpack-plugin": "^0.4.1",
+    "fork-ts-checker-webpack-plugin": "^3.1.1",
     "ts-loader": "^5.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
TSLint is being replaced by ESLint, however the old fork-ts-checker-webpack-plugin used by this typescript plugin is old and didn't support eslint.