### PR TITLE
Updating includes to be future-safe, fixing the suggestions in warnings.

### DIFF
--- a/examples/with-react-loadable/src/App.js
+++ b/examples/with-react-loadable/src/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import Route from 'react-router-dom/Route';
-import Switch from 'react-router-dom/Switch';
+import {Route, Switch} from 'react-router-dom';
 import Home from './Home';
 import './App.css';
 


### PR DESCRIPTION
This change is a fix for the following warnings below:

```
Warning: Please use `require("react-router-dom").Route` instead of `require("react-router-dom/Route")`. Support for the latter will be removed in the next major release.
Warning: Please use `require("react-router-dom").Switch` instead of `require("react-router-dom/Switch")`. Support for the latter will be removed in the next major release.

```