### PR TITLE
add --ignore-engines to github ci

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn global add elm
 
     - name: Install and bootstrap packages
-      run: yarn install --frozen-lockfile     
+      run: yarn install --frozen-lockfile --ignore-engines
 
     - name: Run tests
       run: yarn e2e --runInBand --coverage


### PR DESCRIPTION
### Why?
we have 2 kinds of deps on this project
1) deps for developing the razzle project and maintaining repo (like husky, Lerna)
2) deps for each package ...

if we are going to use the lasted version of Lerna for managing the project we need node 11 but `yarn install` command on node <= 10 will not allow us to install that dep and we can't run the tests on CI server

with this change, it will install those packages and then we test if it works in that specific version on node