### PR TITLE
Fixed windows test in github action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn global add elm
 
     - name: Install and bootstrap packages
-      run: yarn install --frozen-lockfile --ignore-engines --network-timeout 10000
+      run: yarn install --frozen-lockfile --ignore-engines --network-timeout 20000
 
     - name: Run tests
       run: yarn e2e --runInBand --coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn global add elm
 
     - name: Install and bootstrap packages
-      run: yarn install --frozen-lockfile --ignore-engines
+      run: yarn install --frozen-lockfile --ignore-engines --network-timeout 10000
 
     - name: Run tests
       run: yarn e2e --runInBand --coverage

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -2,6 +2,6 @@
   "roots": ["<rootDir>/tests"],
   "collectCoverageFrom": ["**/*.js"],
   "testMatch": [
-    "<rootDir>/tests/**/?(*.)(spec|test).(ts|js)?(x)"
+    "<rootDir>/tests/**/*(*.)@(spec|test).(ts|js)?(x)"
   ]
 }

--- a/test/tests/razzle-start.test.js
+++ b/test/tests/razzle-start.test.js
@@ -22,9 +22,12 @@ describe('razzle start', () => {
     it('should start a dev server', () => {
       let outputTest;
       const run = new Promise(resolve => {
-        const child = shell.exec('./node_modules/.bin/razzle start', () => {
-          resolve(outputTest);
-        });
+        const child = shell.exec(
+          `${path.join('./node_modules/.bin/razzle')} start`,
+          () => {
+            resolve(outputTest);
+          }
+        );
         child.stdout.on('data', data => {
           if (data.includes('Server-side HMR Enabled!')) {
             shell.exec('sleep 5');
@@ -43,7 +46,7 @@ describe('razzle start', () => {
 
     it('should build and run', () => {
       let outputTest;
-      shell.exec('./node_modules/.bin/razzle build');
+      shell.exec(`${path.join('./node_modules/.bin/razzle')} build`);
       const run = new Promise(resolve => {
         const child = shell.exec('node build/server.js', () => {
           resolve(outputTest);


### PR DESCRIPTION
I did the following to fix the windows test:

- testMatch glob pattern change for windows
- github action yarn install network timeout change to 20s
- e2e test fix on windows by path.join