### PR TITLE
Fix windows tests in Github Action and Circle CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn global add elm
 
     - name: Install and bootstrap packages
-      run: yarn install --frozen-lockfile --ignore-engines
+      run: yarn install --frozen-lockfile --ignore-engines --network-timeout 30000
 
     - name: Run tests
       run: yarn e2e --runInBand --coverage

--- a/examples/with-reason-react/package.json
+++ b/examples/with-reason-react/package.json
@@ -18,7 +18,7 @@
     "reason-react": "^0.5.3"
   },
   "devDependencies": {
-    "bs-platform": "^4.0.17",
+    "bs-platform": "^7.2.2",
     "concurrently": "^4.0.1",
     "razzle": "^2.4.1"
   }

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -2,6 +2,6 @@
   "roots": ["<rootDir>/tests"],
   "collectCoverageFrom": ["**/*.js"],
   "testMatch": [
-    "<rootDir>/tests/**/?(*.)(spec|test).(ts|js)?(x)"
+    "<rootDir>/tests/**/*(*.)@(spec|test).(ts|js)?(x)"
   ]
 }

--- a/test/tests/razzle-start.test.js
+++ b/test/tests/razzle-start.test.js
@@ -22,9 +22,12 @@ describe('razzle start', () => {
     it('should start a dev server', () => {
       let outputTest;
       const run = new Promise(resolve => {
-        const child = shell.exec('./node_modules/.bin/razzle start', () => {
-          resolve(outputTest);
-        });
+        const child = shell.exec(
+          `${path.join('./node_modules/.bin/razzle')} start`,
+          () => {
+            resolve(outputTest);
+          }
+        );
         child.stdout.on('data', data => {
           if (data.includes('Server-side HMR Enabled!')) {
             shell.exec('sleep 5');
@@ -43,7 +46,7 @@ describe('razzle start', () => {
 
     it('should build and run', () => {
       let outputTest;
-      shell.exec('./node_modules/.bin/razzle build');
+      shell.exec(`${path.join('./node_modules/.bin/razzle')} build`);
       const run = new Promise(resolve => {
         const child = shell.exec('node build/server.js', () => {
           resolve(outputTest);


### PR DESCRIPTION
I did the following to fix the test:

- testMatch glob pattern change for windows (https://github.com/facebook/jest/issues/7914#issuecomment-464352069)
- github action yarn install network timeout change to 30s
    - I don't know why, but when fetch the resolve-url-loader on windows github action using yarn, it is timed out. upgrading to the latest version will fix the problem, but there is a risk, so added the `--network-timeout 30000` flag instead upgrading to the latest version.
- e2e test fix on windows by path.join
- bs-platform dependency of examples/with-reason-react causes intermittent problems in the 'Install and bootstrap packages' phase of circle ci, so it was changed to the latest version. As it is an example, the risk is expected to be small.