### PR TITLE
Plugins from organisations

### DIFF
--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -18,7 +18,7 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
   const completePluginNames = [`razzle-plugin-${plugin.name}`, `${plugin.name}/razzle-plugin`];
   
   // Try to find the plugin in node_modules
-  const razzlePlugin = null;
+  let razzlePlugin = null;
   for (const completePluginName of completePluginNames) {
     razzlePlugin = require(completePluginName);
   }  

--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -19,7 +19,7 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
   
   // Try to find the plugin in node_modules
   const razzlePlugin = null;
-  for (const completePluginName of completePluginName) {
+  for (const completePluginName of completePluginNames) {
     razzlePlugin = require(completePluginName);
   }  
   

--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -15,12 +15,16 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
     return plugin.func(config, { target, dev }, webpack, plugin.options);
   }
 
-  const completePluginName = `razzle-plugin-${plugin.name}`;
-
+  const completePluginNames = [`razzle-plugin-${plugin.name}`, `${plugin.name}/razzle-plugin`];
+  
   // Try to find the plugin in node_modules
-  const razzlePlugin = require(completePluginName);
+  const razzlePlugin = null;
+  for (const completePluginName of completePluginName) {
+    razzlePlugin = require(completePluginName);
+  }  
+  
   if (!razzlePlugin) {
-    throw new Error(`Unable to find '${completePluginName}`);
+    throw new Error(`Unable to find '${completePluginName[0]}' or '${completePluginName[1]}'`);
   }
 
   return razzlePlugin(config, { target, dev }, webpack, plugin.options);

--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -21,6 +21,9 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
   let razzlePlugin = null;
   for (const completePluginName of completePluginNames) {
     razzlePlugin = require(completePluginName);
+    if (razzlePlugin) {
+      break;
+    }
   }  
   
   if (!razzlePlugin) {


### PR DESCRIPTION
We have an npmjs.org organisation at work. We create packages with names like `@myorg/name`, see: https://docs.npmjs.com/about-org-scopes-and-packages. In an eslint configuration you can write `@myorg` and it will automatically find a package named `@myorder/eslint-config`, see: https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules.

Since we have multiple Razzle applications, we have a Razzle plugin in order to centralize most of our build configuration to one place. The name of that package is `@myorg/razzle-plugin`. This change will allow the same naming convention for Razzle plugins as eslint plugins.

Let me know if you have any feedback.