### PR TITLE
fix: complement CSS loader setup with pre-3.1 configuration

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -191,6 +191,7 @@ module.exports = (
                   options: {
                     importLoaders: 1,
                     modules: { auto: true },
+                    onlyLocals: true,
                   },
                 },
               ]
@@ -214,7 +215,8 @@ module.exports = (
                 {
                   loader: require.resolve('css-loader'),
                   options: {
-                    importLoaders: 1
+                    importLoaders: 1,
+                    modules: { auto: true },
                   },
                 },
                 {


### PR DESCRIPTION
- Noticed that v3.0 [used 'locals' package](https://github.com/jaredpalmer/razzle/blob/v3.0.0/packages/razzle/config/createConfig.js#L230) for CSS modules on
the server, which maps into `onlyLocals` option in new `css-loader`, would this still be needed in new combined configuration?
- Fix missing `modules: { auto: true }` for production client-side
build, see [createConfig.js#L259](https://github.com/jaredpalmer/razzle/blob/v3.0.0/packages/razzle/config/createConfig.js#L259) in v3.0

Was this CSS modules configuration omitted on purpose and what would now be the recommended setup?