### PR TITLE
Fix example code documentation

### DIFF
--- a/examples/with-vendor-bundle/razzle.config.js
+++ b/examples/with-vendor-bundle/razzle.config.js
@@ -1,9 +1,7 @@
 'use strict';
 
 module.exports = {
-  modify(defaultConfig, { target, dev }, webpack) {
-    const config = defaultConfig; // stay immutable here
-
+  modify(config, { target, dev }, webpack) {
     // Change the name of the server output file in production
     if (target === 'web') {
       // modify filenaming to account for multiple entry files


### PR DESCRIPTION
I don't think there is anything Immutable in taking a reference to an object and then modifying the reference like is done in the example of vendor chunking config file. 

We would need a deep copy for true immutability, so best to remove the misleading bit of code, eh? Or is immutability actually required here?

```
> const a = { hello: "world"}
undefined
> const b = a
undefined
> b.hello = "earth"
'earth'
> a.hello
'earth'
```