### PR TITLE
Use contenthash for better longterm caching of JS assets

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -447,8 +447,8 @@ module.exports = (
       config.output = {
         path: paths.appBuildPublic,
         publicPath: dotenv.raw.PUBLIC_PATH || '/',
-        filename: 'static/js/bundle.[chunkhash:8].js',
-        chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
+        filename: 'static/js/bundle.[contenthash:8].js',
+        chunkFilename: 'static/js/[name].[contenthash:8].chunk.js',
         libraryTarget: 'var',
       };
 


### PR DESCRIPTION
## Summary
We should use contenthash instead of chunkhash for better longterm caching of JS assets. chunkhash relies on the whole chunk as opposed to contenthash which relies only on the content of the JS file itself

https://webpack.js.org/guides/caching/#output-filenames