### PR TITLE
feat: allow dev port config

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -107,6 +107,7 @@ module.exports = (
     const portOffset = clientOnly ? 0 : 1;
 
     const devServerPort =
+      (process.env.PORT_DEV && parseInt(process.env.PORT_DEV)) ||
       (process.env.PORT && parseInt(process.env.PORT) + portOffset) ||
       3000 + portOffset;
 


### PR DESCRIPTION
https://github.com/jaredpalmer/razzle/issues/1320

While investigating this it seems like there's a reference to `PORT_DEV` in `setPorts` but it's not actually used.