### PR TITLE
fix: updated spa example with working env var

### DIFF
--- a/examples/basic-spa/public/index.html
+++ b/examples/basic-spa/public/index.html
@@ -3,13 +3,14 @@
 
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" href="<%= process.env.PUBLIC_PATH %>favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="theme-color" content="#000000" />
   <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
+      Notice the use of <%= process.env.PUBLIC_PATH %> in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      Unlike "/favicon.ico" or "favicon.ico", "<%= process.env.PUBLIC_PATH %>/favicon.ico" will
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->


### PR DESCRIPTION
> https://github.com/jaredpalmer/razzle/issues/1359

Updates the [basic-spa](https://github.com/jaredpalmer/razzle/tree/master/examples/basic-spa) example to properly read the PUBLIC_PATH environment variable in order to load the favicon.