### PR TITLE
Update createConfig.js

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -343,7 +343,7 @@ module.exports = (
           const entries = [...entrypoints];
           const entryArrayManifest = entries.reduce((acc, entry) => {
             const name =
-              (entry.options || {}).name || (entry.runtimeChunk || {}).name;
+              (entry.options || {}).name || (entry.runtimeChunk || {}).name || entry.id;
             const files = []
               .concat(
                 ...(entry.chunks || []).map(chunk =>


### PR DESCRIPTION
chunks.json manifest name fallback to entry.id

I'm having a problem where a bunch of assets are missing from my `chunks.json` manifest (that I want to use for caching) and it seems to be because if the chunk doesn't have a name it's completely omitted from the file.

My `chunks.json` before this change:
```json
{
  "client": {
    "css": [],
    "js": [
      "/static/js/bundle.1ed44c52.js",
      "/static/js/bundle.1ed44c52.js.map"
    ]
  }
}
```

After this change:
```json
{
  "0": {
    "css": [],
    "js": [
      "/static/js/0.cb47cee9.chunk.js",
      "/static/js/0.cb47cee9.chunk.js.map"
    ]
  },
  "7": {
    "css": [],
    "js": [
      "/static/js/7.d5d1d330.chunk.js",
      "/static/js/7.d5d1d330.chunk.js.map"
    ]
  },
  "9": {
    "css": [],
    "js": [
      "/static/js/9.81cfe76f.chunk.js",
      "/static/js/9.81cfe76f.chunk.js.map"
    ]
  },
  "10": {
    "css": [],
    "js": [
      "/static/js/10.f6fe13e7.chunk.js",
      "/static/js/10.f6fe13e7.chunk.js.map"
    ]
  },
  "0+1+2+6+8": {
    "css": [],
    "js": [
      "/static/js/0.cb47cee9.chunk.js",
      "/static/js/0.cb47cee9.chunk.js.map",
      "/static/js/1.24fe08db.chunk.js",
      "/static/js/1.24fe08db.chunk.js.map",
      "/static/js/2.085ddb6e.chunk.js",
      "/static/js/2.085ddb6e.chunk.js.map",
      "/static/js/6.70a4f937.chunk.js",
      "/static/js/6.70a4f937.chunk.js.map",
      "/static/js/8.7a0eb212.chunk.js",
      "/static/js/8.7a0eb212.chunk.js.map"
    ]
  },
  "0+1+4": {
    "css": [],
    "js": [
      "/static/js/0.cb47cee9.chunk.js",
      "/static/js/0.cb47cee9.chunk.js.map",
      "/static/js/1.24fe08db.chunk.js",
      "/static/js/1.24fe08db.chunk.js.map",
      "/static/js/4.d1b97dfc.chunk.js",
      "/static/js/4.d1b97dfc.chunk.js.map"
    ]
  },
  "2+3": {
    "css": [],
    "js": [
      "/static/js/2.085ddb6e.chunk.js",
      "/static/js/2.085ddb6e.chunk.js.map",
      "/static/js/3.0f5d4ac7.chunk.js",
      "/static/js/3.0f5d4ac7.chunk.js.map"
    ]
  },
  "client": {
    "css": [],
    "js": [
      "/static/js/bundle.1ed44c52.js",
      "/static/js/bundle.1ed44c52.js.map"
    ]
  }
}
```

I think the main reason I'm running into this issue is because i'm using import expression syntax to allow webpack to bundle-split automatically when/where it can  but it leads to unnamed chunks