### PR TITLE
[fix] Bumped responsive-url-loader from ^2.3.0 ^to 3.1.1

### DIFF
--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -14,7 +14,7 @@
     "node-sass-chokidar": "^1.3.0",
     "postcss-flexbugs-fixes": "^3.3.1",
     "postcss-scss": "^1.0.5",
-    "resolve-url-loader": "^2.3.0",
+    "resolve-url-loader": "^3.1.1",
     "sass-loader": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
responsive-url-loader prior to v 3.0.0 considered the CSS `@apply` Rule as a syntax error (among others).
For instance, this makes it impossible to use tools like tailwindcss that rely on the usage of @apply.

From [Version 3](https://www.npmjs.com/package/resolve-url-loader#version-3) the library uses the engine 'postcss' instead of 'rework' solving this issue.

> Version 3
>Features
> * Use postcss parser by default. This is long overdue as the old rework parser doesn't cope with modern css.

Source: https://www.npmjs.com/package/resolve-url-loader#version-3

Making this upgrade doesn't break any test. Also, the migration guide shows that no other change has to be done on this repo.
