### PR TITLE
Added async and await to test command

### DIFF
--- a/packages/razzle/scripts/test.js
+++ b/packages/razzle/scripts/test.js
@@ -45,11 +45,11 @@ const fs = require('fs-extra');
 const defaultPaths = require('../config/paths');
 
 loadRazzleConfig(webpack, defaultPaths).then(
-  ({ razzle, webpackObject, plugins, paths }) => {
+  async ({ razzle, webpackObject, plugins, paths }) => {
     argv.push(
       '--config',
       JSON.stringify(
-        createJestConfig(
+        await createJestConfig(
           relativePath => path.resolve(__dirname, '..', relativePath),
           path.resolve(paths.appSrc, '..'),
           razzle,


### PR DESCRIPTION
While trying to upgrade Razzle to a version that did not have the deprecation warning, I noticed that razzle's createJestConfig function had been changed to a promise but was not being consumed using async and await. This resulted in custom configs not being pulled in properly from the package.json. I've added async and await, and tested the test command to ensure it works properly. 

This is my first pull request on an open source project, not sure if I'm following proper procedures, but thanks for the hard work! 