### PR TITLE
docs(plugin-typescript): add link to example

### DIFF
--- a/packages/razzle-plugin-typescript/README.md
+++ b/packages/razzle-plugin-typescript/README.md
@@ -18,6 +18,8 @@ module.exports = {
 };
 ```
 
+See full configuration in the [typescript example project](https://github.com/jaredpalmer/razzle/tree/master/examples/with-typescript).
+
 ### With custom options:
 
 ```js


### PR DESCRIPTION
Added a reference to the typescript plugin example, to see the full configuration (e.g. `tsconfig.json`, `tslint.json` & `package.json`)