### PR TITLE
feat(razzle): add Yarn PnP support

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,8 @@
     }
   },
   "lint-staged": {
-    "*.{js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|mdx}": [
-      "prettier --trailing-comma es5 --single-quote --write",
-      "git add"
+    "*.{js,jsx,json,yml,yaml,css,less,scss,ts,tsx,md,mdx}": [
+      "prettier --trailing-comma es5 --single-quote --write"
     ]
   },
   "dependencies": {},

--- a/packages/babel-preset-razzle/index.js
+++ b/packages/babel-preset-razzle/index.js
@@ -29,6 +29,7 @@ var preset = {
         absoluteRuntime: path.dirname(
           require.resolve("@babel/runtime/package.json")
         ),
+        version: require('@babel/runtime/package.json').version
       },
     ],
   ],

--- a/packages/babel-preset-razzle/index.js
+++ b/packages/babel-preset-razzle/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require("path")
+
 var preset = {
   presets: [
     [require.resolve('@babel/preset-env'), { modules: false }],
@@ -21,7 +23,14 @@ var preset = {
     // Adds syntax support for import()
     require.resolve('@babel/plugin-syntax-dynamic-import'),
     // Add support for async/await
-    require.resolve('@babel/plugin-transform-runtime'),
+    [
+      require.resolve("@babel/plugin-transform-runtime"),
+      {
+        absoluteRuntime: path.dirname(
+          require.resolve("@babel/runtime/package.json")
+        ),
+      },
+    ],
   ],
 };
 

--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -20,6 +20,7 @@
     "chalk": "3.0.0",
     "jest-message-util": "^24.9.0",
     "react-dev-utils": "^10.2.0",
+    "react-error-overlay": "^6.0.7",
     "strip-ansi": "6.0.0",
     "webpack-dev-server": "~3.10.3",
     "sockjs-client": "^1.5.0"

--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -21,6 +21,7 @@
     "jest-message-util": "^24.9.0",
     "react-dev-utils": "^10.2.0",
     "strip-ansi": "6.0.0",
-    "webpack-dev-server": "~3.10.3"
+    "webpack-dev-server": "~3.10.3",
+    "sockjs-client": "^1.5.0"
   }
 }

--- a/packages/razzle-plugin-typescript/package.json
+++ b/packages/razzle-plugin-typescript/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "fork-ts-checker-webpack-plugin": "^3.1.1",
-    "ts-loader": "^5.2.1"
+    "ts-loader": "^5.2.1",
+    "razzle-dev-utils": "^3.1.7"
   },
   "devDependencies": {
     "razzle": "^3.1.7"

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -286,10 +286,10 @@ module.exports = (
     if (IS_DEV) {
       // Use watch mode
       config.watch = true;
-      config.entry.unshift('webpack/hot/poll?300');
+      config.entry.unshift(`${require.resolve('webpack/hot/poll')}?300`);
 
       // Pretty format server errors
-      config.entry.unshift('razzle-dev-utils/prettyNodeErrors');
+      config.entry.unshift(require.resolve('razzle-dev-utils/prettyNodeErrors'));
 
       const nodeArgs = ['-r', require.resolve('source-map-support/register')];
 

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -291,7 +291,7 @@ module.exports = (
       // Pretty format server errors
       config.entry.unshift('razzle-dev-utils/prettyNodeErrors');
 
-      const nodeArgs = ['-r', 'source-map-support/register'];
+      const nodeArgs = ['-r', require.resolve('source-map-support/register')];
 
       // Passthrough --inspect and --inspect-brk flags (with optional [host:port] value) to node
       if (process.env.INSPECT_BRK) {

--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -17,6 +17,7 @@ const getClientEnv = require('./env').getClientEnv;
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
 const WebpackBar = require('webpackbar');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const PnpWebpackPlugin = require(`pnp-webpack-plugin`);
 const modules = require('./modules');
 
 const postCssOptions = {
@@ -113,9 +114,17 @@ module.exports = (
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
         'react-native': 'react-native-web',
       },
+      plugins: [
+        // TODO: Remove when using webpack 5
+        PnpWebpackPlugin,
+      ],
     },
     resolveLoader: {
       modules: [paths.appNodeModules, paths.ownNodeModules],
+      plugins: [
+        // TODO: Remove when using webpack 5
+        PnpWebpackPlugin.moduleLoader(module),
+      ],
     },
     module: {
       strictExportPresence: true,

--- a/packages/razzle/config/runPlugin.js
+++ b/packages/razzle/config/runPlugin.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const resolve = require('resolve')
+const paths = require('./paths')
+
 function runPlugin(plugin, config, { target, dev }, webpack) {
   if (typeof plugin === 'string') {
     // Apply the plugin with default options if passing only a string
@@ -18,7 +21,7 @@ function runPlugin(plugin, config, { target, dev }, webpack) {
   const completePluginName = `razzle-plugin-${plugin.name}`;
 
   // Try to find the plugin in node_modules
-  const razzlePlugin = require(completePluginName);
+  const razzlePlugin = require(resolve.sync(completePluginName, { basedir: paths.appRazzleConfig }));
   if (!razzlePlugin) {
     throw new Error(`Unable to find '${completePluginName}`);
   }

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -38,6 +38,7 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-safe-parser": "^4.0.2",
     "razzle-dev-utils": "^3.1.7",
+    "resolve": "^1.17.0",
     "react-dev-utils": "^10.2.0",
     "react-error-overlay": "^6.0.6",
     "sade": "^1.4.2",

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -33,6 +33,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "mri": "^1.1.4",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
+    "pnp-webpack-plugin": "^1.6.4",
     "postcss-flexbugs-fixes": "^4.2.0",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14514,6 +14514,11 @@ react-error-overlay@^6.0.6:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.6.tgz#ac4d9dc4c1b5c536c2c312bf66aa2b09bfa384e2"
   integrity sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==
 
+react-error-overlay@^6.0.7:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
+  integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
+
 react-is@^16.12.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,7 +5690,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
+debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -6978,6 +6978,13 @@ faye-websocket@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
   integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
+  integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -8534,7 +8541,7 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
-inherits@2.0.4:
+inherits@2.0.4, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -10593,6 +10600,11 @@ json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
+
+json3@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
+  integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
@@ -14383,6 +14395,11 @@ querystringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -15838,6 +15855,18 @@ sockjs-client@1.4.0:
     json3 "^3.3.2"
     url-parse "^1.4.3"
 
+sockjs-client@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.0.tgz#2f8ff5d4b659e0d092f7aba0b7c386bd2aa20add"
+  integrity sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==
+  dependencies:
+    debug "^3.2.6"
+    eventsource "^1.0.7"
+    faye-websocket "^0.11.3"
+    inherits "^2.0.4"
+    json3 "^3.3.3"
+    url-parse "^1.4.7"
+
 sockjs@0.3.19:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
@@ -17285,6 +17314,14 @@ url-parse@^1.4.3:
   integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
   dependencies:
     querystringify "^2.0.0"
+    requires-port "^1.0.0"
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
     requires-port "^1.0.0"
 
 url-template@^2.0.8:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15169,6 +15169,13 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 responselike@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13357,6 +13357,13 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+pnp-webpack-plugin@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
+  integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  dependencies:
+    ts-pnp "^1.1.6"
+
 portfinder@^1.0.25:
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.25.tgz#254fd337ffba869f4b9d37edc298059cb4d35eca"
@@ -16922,6 +16929,11 @@ ts-loader@^5.2.1:
     loader-utils "^1.0.2"
     micromatch "^3.1.4"
     semver "^5.0.1"
+
+ts-pnp@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
+  integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tslib@^1.10.0:
   version "1.11.1"


### PR DESCRIPTION
**What's the problem this PR addresses?**

`razzle` doesn't work with Yarn PnP due to missing dependencies and incorrect assumptions about the `node_modules` layout.

ref https://github.com/jaredpalmer/razzle/issues/896

**How did you fix it?**

- Add undeclared dependencies
- `require.resolve` things that the user isn't responsible for providing
- Resolve plugins relative to the config
- Add https://github.com/arcanis/pnp-webpack-plugin (only PnP specific thing)

**Notes**
This only adds PnP support to `razzle`, the various plugins haven't been fixed as some of them require upstream changes