### PR TITLE
Updating to latest typescript, ts-loader, and fork-ts-checker-webpack-plugin

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -28,7 +28,7 @@
     "@types/webpack-env": "^1.15.2",
     "razzle": "4.0.0-finch.11",
     "razzle-dev-utils": "4.0.0-finch.11",
-    "typescript": "^3.8.3",
+    "typescript": "^4.0.3",
     "mini-css-extract-plugin": "^0.9.0",
     "webpack": "^4.44.1",
     "babel-preset-razzle": "4.0.0-finch.11",

--- a/packages/razzle-plugin-typescript/README.md
+++ b/packages/razzle-plugin-typescript/README.md
@@ -40,10 +40,9 @@ module.exports = {
           experimentalWatchApi: true,
         },
         forkTsChecker: {
-          tsconfig: './tsconfig.json',
-          tslint: './tslint.json',
-          watch: './src',
-          typeCheck: true,
+          eslint: {
+            files: ['*.js', '*.jsx', '*.ts', '*.tsx'],
+          }
         },
       },
     },
@@ -61,6 +60,6 @@ Set `useBabel` to `true` if you want to keep using `babel` for _JS_/_TS_ interop
 
 Use this to override [`ts-loader`](https://github.com/TypeStrong/ts-loader) options. Check all the options here: [ts-loader options](https://github.com/TypeStrong/ts-loader#loader-options).
 
-**forkTsChecker: _TSCheckerOptions_** (defaults: { tsconfig: './tsconfig.json', tslint: './tslint.json', watch: './src', typeCheck: true })
+**forkTsChecker: _TSCheckerOptions_** (defaults: { async: 'compiler.options.mode === 'development'', typescript: true, eslint: undefined, issue: {}, formatter: 'codeframe', logger: { infrastructure: 'silent', issues: 'console', devServer: true } })
 
 Use this to override [`fork-ts-checker-webpack-plugin`](https://github.com/Realytics/fork-ts-checker-webpack-plugin) options. Check all the options here: [fork-ts-checker-webpack-plugin options](https://github.com/Realytics/fork-ts-checker-webpack-plugin#options).

--- a/packages/razzle-plugin-typescript/index.js
+++ b/packages/razzle-plugin-typescript/index.js
@@ -10,9 +10,9 @@ const defaultOptions = {
     experimentalWatchApi: true,
   },
   forkTsChecker: {
-    tsconfig: './tsconfig.json',
-    tslint: './tslint.json',
-    watch: ['./src'],
+    eslint: {
+      files: ['*.js', '*.jsx', '*.ts', '*.tsx'],
+    }
   },
 };
 

--- a/packages/razzle-plugin-typescript/package.json
+++ b/packages/razzle-plugin-typescript/package.json
@@ -10,17 +10,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "fork-ts-checker-webpack-plugin": "^3.1.1",
-    "ts-loader": "^5.2.1"
+    "fork-ts-checker-webpack-plugin": "^5.2.0",
+    "ts-loader": "^8.0.4"
   },
   "devDependencies": {
     "razzle": "4.0.0-finch.11",
-    "tslint": "^6.1.2",
-    "typescript": ">=2.4.1"
+    "typescript": ">=4.0.3"
   },
   "peerDependencies": {
     "razzle-dev-utils": "4.0.0-finch.11",
-    "tslint": "^6.1.2",
-    "typescript": ">=2.4.1"
+    "typescript": ">=4.0.3"
   }
 }


### PR DESCRIPTION
# Updating the razzle-plugin-typescript package

Updating versions of `typescript`, `ts-loader`, and `fork-ts-checker-webpack-plugin` for the `razzle-plugin-typescript` package.

- tslint is deprecated in favor of eslint. tslint is not maintained anymore read more here
- tsc compile watch: there's no changes
- the new options for fork-ts-checker can be found here

_(I'm not sure if there's any specific default ones you want to have besides the files that should be linted)_

## Test
 - run the `npm test` in the `packages/razzle-plugin-typescript` folder
