### PR TITLE
Add prefresh example to finch

### DIFF
--- a/examples/with-preact/.gitignore
+++ b/examples/with-preact/.gitignore
@@ -11,3 +11,4 @@ public/static
 .env.development.local
 .env.test.local
 .env.production.local
+cache

--- a/examples/with-preact/package.json
+++ b/examples/with-preact/package.json
@@ -9,17 +9,20 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "dependencies": {
+    "@prefresh/babel-plugin": "^0.2.0",
+    "@prefresh/webpack": "^2.0.0",
     "express": "^4.17.1",
     "preact": "^10.4.1",
-    "preact-render-to-string": "^5.1.6"
+    "preact-render-to-string": "^5.1.6",
+    "react": "^16.13.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.9.4",
+    "babel-preset-razzle": "4.0.0-finch.11",
+    "mini-css-extract-plugin": "^0.9.0",
     "razzle": "4.0.0-finch.11",
     "razzle-dev-utils": "4.0.0-finch.11",
-    "mini-css-extract-plugin": "^0.9.0",
     "webpack": "^4.44.1",
-    "babel-preset-razzle": "4.0.0-finch.11",
     "webpack-dev-server": "^3.11.0"
   }
 }

--- a/examples/with-preact/razzle.config.js
+++ b/examples/with-preact/razzle.config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const Prefresh = require('@prefresh/webpack');
+
+module.exports = {
+  experimental: {
+    reactRefresh: false,
+  },
+  modifyWebpackConfig(opts) {
+    const { target, dev } = opts.env;
+    const { webpackConfig: config } = opts;
+    if (target !== 'node' && dev) {
+      const jsRule = config.module.rules.find(loaderEntry =>
+        String(loaderEntry.test).includes('(js|jsx|mjs|ts|tsx)')
+      );
+
+      const babelLoader = jsRule.use.find(useEntry =>
+        useEntry.loader.includes('babel-loader')
+      );
+
+      if (babelLoader.options.plugins) {
+        babelLoader.options.plugins.unshift('@prefresh/babel-plugin');
+      } else {
+        babelLoader.options.plugins = ['@prefresh/babel-plugin'];
+      }
+
+      config.plugins.unshift(new Prefresh());
+    }
+
+    return config;
+  },
+};

--- a/examples/with-preact/src/App.js
+++ b/examples/with-preact/src/App.js
@@ -1,17 +1,19 @@
-import { h, Component } from "preact";
-import PreactLogo from "./preact.svg";
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+import PreactLogo from './preact.svg';
 /** @jsx h */
 
-class App extends Component {
-  // Preact!
-  render(props, state) {
-    return (
-      <div class="Preact">
-        <img src={PreactLogo} alt="Preact Logo" />
-        Hello Preact!
-      </div>
-    );
-  }
-}
+const App = () => {
+  const [count, setCount] = useState(0);
+  return (
+    <main class="Preact">
+      <img src={PreactLogo} alt="Preact Logo" />
+      Hello Preact!
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count - 1)}>-</button>
+      <button onClick={() => setCount(count + 1)}>+</button>
+    </main>
+  );
+};
 
 export default App;

--- a/examples/with-preact/src/client.js
+++ b/examples/with-preact/src/client.js
@@ -2,15 +2,4 @@ import { h, hydrate } from "preact";
 import App from "./App";
 /** @jsx h */
 
-let root;
-function renderApp() {
-  root = hydrate(<App />, document.body, document.body.firstElementChild);
-  return root;
-}
-
-// Initial render.
-renderApp();
-
-if (module.hot) {
-  module.hot.accept("./App", renderApp);
-}
+hydrate(<App />, document.body, document.body.firstElementChild);


### PR DESCRIPTION
In finch razzle seems to have a bug where it hard-requires React so the Preact example is broken, due to this bug I temp added React as a dependency. The odd one out is that the HMR-runtime used inside of razzle seems broken since it can never find the generated hot-update file.