### PR TITLE
Missing comma in `FriendlyErrorsPlugin` code snippet

### DIFF
--- a/packages/razzle-dev-utils/README.md
+++ b/packages/razzle-dev-utils/README.md
@@ -36,7 +36,7 @@ module.exports = {
   plugins: [
     new FriendlyErrorsPlugin({
         verbose: false,
-        target: 'web'
+        target: 'web',
         onSuccessMessage: `Your application is running at http://${process.env.HOST}:${process.env.PORT}`,
       }),
     // ...


### PR DESCRIPTION
added comma since missing in docs.