### PR TITLE
MDX Plugin: update README.md

### DIFF
--- a/packages/razzle-plugin-mdx/README.md
+++ b/packages/razzle-plugin-mdx/README.md
@@ -36,7 +36,7 @@ module.exports = {
     {
       name: 'mdx',
       options: {
-        mdPlugins: [images, emoji],
+        remarkPlugins: [images, emoji],
       },
     },
   ],


### PR DESCRIPTION

it looks like they changed `mdPlugins` to `remarkPlugins` 

https://mdxjs.com/getting-started/webpack#using-plugins