### PR TITLE
Support for not released plugins

### DIFF
--- a/packages/razzle/config/loadPlugins.js
+++ b/packages/razzle/config/loadPlugins.js
@@ -12,6 +12,11 @@ function loadPlugin(plugin, paths) {
     return [plugin, {}];
   }
 
+  // Support for not released plugins
+  if (typeof plugin === 'object') {
+    return [plugin, {}];
+  }
+
   if (typeof plugin.func === 'function') {
     // Used for writing plugin tests
     return [plugin.func, plugin.options];
@@ -36,7 +41,7 @@ function loadPlugin(plugin, paths) {
 }
 
 function loadPlugins(plugins, paths) {
-  return plugins.map(function(plugin) {
+  return plugins.map(function (plugin) {
     return loadPlugin(plugin, paths);
   });
 }


### PR DESCRIPTION
Sometimes, you want to add a plugin that is not released to npm, but has the form of a local module. 
You are able to do that as a function, but not using the new object shaped plugins.
Thanks for the awesome job.