### PR TITLE
Support for not released plugins in razzle.config.js

### DIFF
--- a/packages/razzle/config/loadPlugins.js
+++ b/packages/razzle/config/loadPlugins.js
@@ -12,6 +12,11 @@ function loadPlugin(plugin, paths) {
     return [plugin, {}];
   }
 
+  // Support for not released plugins
+  if (typeof plugin === 'object') {
+    return [plugin, {}];
+  }
+
   if (typeof plugin.func === 'function') {
     // Used for writing plugin tests
     return [plugin.func, plugin.options];


### PR DESCRIPTION
Sometimes, you want to add a plugin that is not released to npm, but has the form of a local module.
You are able to do that as a function, but not using the new object shaped plugins.