### PR TITLE
Add documentation for non-relative module imports.

### DIFF
--- a/website/pages/docs/customization.md
+++ b/website/pages/docs/customization.md
@@ -20,6 +20,40 @@ module.exports = {
 
 More options will be added in the future, some options now in experimental will be moved here.
 
+## Absolute Imports
+
+You can configure your application to support importing modules using absolute paths. This can be done by configuring a jsconfig.json or tsconfig.json file in the root of your project. If you're using TypeScript in your project, you will already have a tsconfig.json file.
+
+Below is an example jsconfig.json file for a JavaScript project (or tsconfig.json if you're using TypeScript). You can create the file if it doesn't already exist:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}
+```
+
+To make the Jest test runner work with absolute imports, you'll need to add a `jest` configuration option to your package.json:
+
+```jsonc
+{
+  "name": "my-razzle-app",
+  "version": "1.0.0",
+  "license": "MIT",
+  /* ...dependencies, etc... */
+  "jest": {
+    "moduleDirectories": ["node_modules", "src"]
+  }
+}
+```
+
+Now that you've configured your project to support absolute imports, if you want to import a module located at src/components/Button.js, you can import the module like so:
+```js
+import Button from 'components/Button';
+```
+
 ## Plugins
 
 As of Razzle 2.0, you can add your plugins to modify your setup.


### PR DESCRIPTION
Non-relative module support isn't currently documented except for a comment in #1112. I wasn't aware that you could also set module base directories in package.json -> jest, so it took me a lot of back and forth before I finally figured it out. I think rather than trying to automate the jest configuration based on the `baseUrl` setting, an update to the documentation is a more appropriate solution. This addresses #1466.

Edit: I just found discussions in #1410 and #1206 as well.