### PR TITLE
Use Dart sass instead of deprecated node-sass

### DIFF
--- a/packages/razzle-plugin-scss/package.json
+++ b/packages/razzle-plugin-scss/package.json
@@ -13,12 +13,12 @@
     "autoprefixer": "10.0.1",
     "css-loader": "5.0.0",
     "deepmerge": "4.2.2",
-    "node-sass-chokidar": "1.5.0",
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-load-config": "3.0.0",
     "postcss-loader": "4.0.4",
     "postcss-scss": "3.0.2",
     "resolve-url-loader": "3.1.2",
+    "sass": "^1.29.0",
     "sass-loader": "10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Webpack sass-loader recommends this, node-sass doesn't work with PnP either.

Dart sass tends to install faster too, as it doesn't need to compile libsass as far as I understand 