### PR TITLE
Fix error running with-typescript example

### DIFF
--- a/examples/with-typescript/src/index.ts
+++ b/examples/with-typescript/src/index.ts
@@ -18,10 +18,6 @@ const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
 export default express()
   .use((req, res) => app.handle(req, res))
-  .listen(port, (err: Error) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
+  .listen(port, () => {
     console.log(`> App started http://localhost:${port}`)
   });


### PR DESCRIPTION
Fixes the following error -

```
src/index.ts:22:17 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type '(err: Error) => void' is not assignable to parameter of type '() => void'.

22   .listen(port, (err: Error) => {
                   ~~~~~~~~~~~~~~~~~
```

Closes #1478