### PR TITLE
Adds missing localIdentName configuration in the createConfigAsync.js…

### DIFF
--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -604,7 +604,10 @@ module.exports = (
                     loader: require.resolve('css-loader'),
                     options: {
                       importLoaders: 1,
-                      modules: { auto: true },
+                      modules: {
+                        auto: true,
+                        localIdentName: '[name]__[local]___[hash:base64:5]',
+                      },
                       onlyLocals: true,
                     },
                   },


### PR DESCRIPTION
Hello

This is a simple straight-forward fix that adds a missing configuration element for the createConfigAsync file. Without this fix, projects can have a certain className generated in the HTML and a different className in the css files.