### PR TITLE
Fix babel-jest with babelrc

### DIFF
--- a/packages/razzle/config/jest/babelTransform.js
+++ b/packages/razzle/config/jest/babelTransform.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra');
 const hasBabelRc = fs.existsSync(paths.appBabelRc);
 
 const config = {
-  presets: !hasBabelRc && [require.resolve('babel-preset-razzle')],
+  presets: !hasBabelRc ? [require.resolve('babel-preset-razzle')] : [],
   babelrc: !!hasBabelRc,
 };
 


### PR DESCRIPTION
`createTransformer` used to be able to accept `presets: false` but with [this](https://github.com/facebook/jest/pull/9766/files#diff-5f463bc5dbe428998302335614e9bbed3b4eb3310a6075767e1b432c161d9e71R56) change it now requires `null` or `undefined` (logic changed from `||` to `??`)