### PR TITLE
fix(razzle): Improve SIGINT/SIGTERM handling.

### DIFF
--- a/packages/razzle-start-server-webpack-plugin/dist/StartServerPlugin.js
+++ b/packages/razzle-start-server-webpack-plugin/dist/StartServerPlugin.js
@@ -41,7 +41,13 @@ class StartServerPlugin {
       signal: false,
       // Send a signal instead of a message
       // Only listen on keyboard in development, so the server doesn't hang forever
-      restartable: process.env.NODE_ENV === 'development'
+      restartable: process.env.NODE_ENV === 'development',
+      killOnExit: true,
+      // issue SIGKILL on child process exit
+      killOnError: true,
+      // issue SIGKILL on child process error
+      killTimeout: 1000 // timeout before SIGKILL in milliseconds
+
     }, options);
 
     if (this.options.args) {
@@ -64,6 +70,7 @@ class StartServerPlugin {
     this._handleChildQuit = this._handleChildQuit.bind(this);
     this._handleChildMessage = this._handleChildMessage.bind(this);
     this._handleWebpackExit = this._handleWebpackExit.bind(this);
+    this._handleProcessKill = this._handleProcessKill.bind(this);
     this.worker = null;
 
     if (this.options.restartable && !options.once) {
@@ -166,6 +173,12 @@ class StartServerPlugin {
       this.workerLoaded = false;
 
       this._runWorker();
+
+      return;
+    }
+
+    if (this.options.killOnExit) {
+      this._handleProcessKill();
     }
   }
 
@@ -176,7 +189,23 @@ class StartServerPlugin {
   }
 
   _handleChildError(err) {
+    this._error('Script errored');
+
     this.worker = null;
+
+    if (this.options.killOnError) {
+      this._handleProcessKill();
+    }
+  }
+
+  _handleProcessKill() {
+    const pKill = () => process.kill(process.pid, 'SIGKILL');
+
+    if (!isNaN(this.options.killTimeout)) {
+      setTimeout(pKill, this.options.killTimeout);
+    } else {
+      pKill();
+    }
   }
 
   _handleChildMessage(message) {

--- a/packages/razzle-start-server-webpack-plugin/dist/StartServerPlugin.js
+++ b/packages/razzle-start-server-webpack-plugin/dist/StartServerPlugin.js
@@ -146,31 +146,27 @@ class StartServerPlugin {
   }
 
   _handleChildExit(code, signal) {
-    if (code) this._error('script exited with code', code);
+    this._error(`Script exited with ${signal ? `signal ${signal}` : `code ${code}`}`);
+
     this.worker = null;
 
-    if (signal && signal !== 'SIGTERM') {
-      this._error('script exited after signal', signal);
+    if (code === 143 || signal === 'SIGTERM') {
+      if (!this.workerLoaded) {
+        this._error('Script did not load, or HMR failed; not restarting');
 
-      process.exit();
-      return;
+        return;
+      }
+
+      if (this.options.once) {
+        this._info('Only running script once, as requested');
+
+        return;
+      }
+
+      this.workerLoaded = false;
+
+      this._runWorker();
     }
-
-    if (!this.workerLoaded) {
-      this._error('Script did not load, or HMR failed; not restarting');
-
-      return;
-    }
-
-    if (this.options.once) {
-      this._info('Only running script once, as requested');
-
-      return;
-    }
-
-    this.workerLoaded = false;
-
-    this._runWorker();
   }
 
   _handleWebpackExit() {

--- a/packages/razzle-start-server-webpack-plugin/src/StartServerPlugin.js
+++ b/packages/razzle-start-server-webpack-plugin/src/StartServerPlugin.js
@@ -118,26 +118,22 @@ export default class StartServerPlugin {
   }
 
   _handleChildExit(code, signal) {
-    if (code) this._error('script exited with code', code);
-
+    this._error(`Script exited with ${signal ? `signal ${signal}` : `code ${code}`}`);
     this.worker = null;
 
-    if (signal && signal !== 'SIGTERM'){
-      this._error('script exited after signal', signal);
-      process.exit()
-      return;
-    }
-    if (!this.workerLoaded) {
-      this._error('Script did not load, or HMR failed; not restarting');
-      return;
-    }
-    if (this.options.once) {
-      this._info('Only running script once, as requested');
-      return;
-    }
+    if (code === 143 || signal === 'SIGTERM') {
+      if (!this.workerLoaded) {
+        this._error('Script did not load, or HMR failed; not restarting');
+        return;
+      }
+      if (this.options.once) {
+        this._info('Only running script once, as requested');
+        return;
+      }
 
-    this.workerLoaded = false;
-    this._runWorker();
+      this.workerLoaded = false;
+      this._runWorker();
+    }
   }
 
   _handleWebpackExit() {

--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -653,6 +653,8 @@ module.exports = (
               verbose: razzleOptions.verbose,
               name: 'server.js',
               entryName: 'server',
+              killOnExit: false,
+              killOnError: false,
               nodeArgs,
             }),
           // Ignore assets.json and chunks.json to avoid infinite recompile bug

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -53,6 +53,7 @@
     "source-map-support": "^0.5.16",
     "string-hash": "1.1.3",
     "style-loader": "2.0.0",
+    "terminate": "2.1.2",
     "terser-webpack-plugin": "^2.3.5",
     "tiny-async-pool": "^1.1.0",
     "url-loader": "^2.3.0",

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -13,6 +13,15 @@ const clearConsole = require('react-dev-utils/clearConsole');
 const logger = require('razzle-dev-utils/logger');
 const setPorts = require('razzle-dev-utils/setPorts');
 const chalk = require('chalk');
+const terminate = require('terminate');
+
+process.once('SIGINT', () => {
+  console.error(chalk.bgRedBright(' SIGINT '), chalk.redBright('exiting...'));
+  terminate(process.pid, 'SIGINT', { timeout: 1000 }, () => {
+    console.error(chalk.bgGreen(' Goodbye '));
+    terminate(process.pid);
+  });
+});
 
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
@@ -140,6 +149,9 @@ function main() {
           ['SIGINT', 'SIGTERM'].forEach(sig => {
             process.on(sig, () => {
               clientDevServer.close();
+              if (watching) {
+                watching.close();
+              }
             });
           });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13076,7 +13076,7 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-ps-tree@1.2.0:
+ps-tree@1.2.0, ps-tree@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
   integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
@@ -15353,6 +15353,13 @@ terminal-link@^2.0.0:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
+
+terminate@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/terminate/-/terminate-2.1.2.tgz#3c78b9dc7559cb66af215c622cce906d415e2ef9"
+  integrity sha512-ltKc9MkgcRe7gzD7XSttHCF1feKM1pTkCdb58jFVWk1efPN9JIk/BHSlOaYF+hCcWoubeJQ8C8Phb0++fa6iNQ==
+  dependencies:
+    ps-tree "^1.1.1"
 
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"


### PR DESCRIPTION
start.js:
- Close server watcher on SIGINT/SIGTERM.

StartServerPlugin.js:
- On SIGINT, if the child process SIGINT handler is not in place yet or 5 seconds have elapsed, exit right away.
- On non-SIGTERM signals, if the child process SIGINT handler is in place, exit once the child process has exited. This allows the (http) server to go through its SIGINT shutdown sequence if any.