### PR TITLE
fix(razzle-plugins): postcss options not applied by razzle-plugin-scss

### DIFF
--- a/packages/razzle-plugin-scss/index.js
+++ b/packages/razzle-plugin-scss/index.js
@@ -113,7 +113,7 @@ module.exports = {
       options: hasPostCssConfig()
         ? undefined
         : { postcssOptions: Object.assign({}, options.postcss[constantEnv], {
-            plugins: () => options.postcss.plugins,
+            plugins: options.postcss.plugins,
           })},
     };
 


### PR DESCRIPTION
This fixes things like browserlist etc not being properly applied, avoid this warning:

`You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.`
