### PR TITLE
feature(razzle): new writeCssDev razzle option

### DIFF
--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -526,7 +526,8 @@ module.exports = (
             ]
             : IS_DEV
             ? [
-              require.resolve('style-loader'),
+              razzleOptions.writeCssDev
+                ?  MiniCssExtractPlugin.loader : require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
                 options: {
@@ -666,6 +667,12 @@ module.exports = (
     }
 
     if (IS_WEB) {
+      // Extract our CSS into files.
+      const miniCssExtractPlugin = new MiniCssExtractPlugin({
+        filename: webpackOptions.cssOutputFilename,
+        chunkFilename: webpackOptions.cssOutputChunkFilename,
+      });
+
       config.plugins = [
         webpackMajor === 5 && new webpack.ProvidePlugin({
           Buffer: [require.resolve('buffer'), 'Buffer'],
@@ -806,6 +813,7 @@ module.exports = (
               })
             : null,
           new webpack.DefinePlugin(webpackOptions.definePluginOptions),
+          razzleOptions.writeCssDev ? miniCssExtractPlugin : null,
         ].filter(x => x);
 
         config.optimization = {
@@ -845,11 +853,7 @@ module.exports = (
           ...config.plugins,
           // Define production environment vars
           new webpack.DefinePlugin(webpackOptions.definePluginOptions),
-          // Extract our CSS into files.
-          new MiniCssExtractPlugin({
-            filename: `${razzleOptions.cssPrefix}/[name].[contenthash:8].css`,
-            chunkFilename: `${razzleOptions.cssPrefix}/[name].[contenthash:8].chunk.css`,
-          }),
+          miniCssExtractPlugin,
           webpackMajor === 5 ? null : new webpack.HashedModuleIdsPlugin(),
           new webpack.optimize.AggressiveMergingPlugin(),
           hasPublicDir && new CopyPlugin({

--- a/packages/razzle/config/defaultOptions.js
+++ b/packages/razzle/config/defaultOptions.js
@@ -11,4 +11,5 @@ module.exports = {
   enableBabelCache: true,
   forceRuntimeEnvVars: [],
   mediaPrefix: 'static/media',
+  writeCssDev: false,
 };

--- a/website/pages/docs/customization.md
+++ b/website/pages/docs/customization.md
@@ -29,6 +29,7 @@ module.exports = {
       windowRoutesDataVariable: 'RAZZLE_STATIC_DATA_ROUTES'
     },
     browserslist: undefined, // or what your apps package.json says
+    writeCssDev: false, // add stylesheet link tag in header in development build
   },
 };
 ```


### PR DESCRIPTION
resolves jaredpalmer/razzle#1509

This option adds stylesheet link tags in the header for the development build, similar to the production build. It allows to
test this functionality in development (and avoid the Flash Of Unstyled Content effect), but prevents hot reloading when the css is updated. It is turned off by default.