### PR TITLE
feat(razzle): disable prompt on CI

### DIFF
--- a/packages/razzle/scripts/build.js
+++ b/packages/razzle/scripts/build.js
@@ -39,7 +39,7 @@ loadRazzleConfig(webpack).then(
   async ({ razzle, razzleOptions, webpackObject, plugins, paths }) => {
     const verbose = razzleOptions.verbose;
 
-    if (process.env.NODE_ENV === "production" && (process.env.RAZZLE_NONINTERACTIVE !== "true" && !cliArgs['noninteractive'])) {
+    if (!process.env.CI && process.env.NODE_ENV === "production" && (process.env.RAZZLE_NONINTERACTIVE !== "true" && !cliArgs['noninteractive'])) {
       await inquirer.prompt([
         {
           type: 'confirm',


### PR DESCRIPTION
If the CI env var is set we should not show the prompt as the CI is by default not interactive.