### PR TITLE
fix(razzle-dev-utils): correct webpack 4 format

### DIFF
--- a/packages/razzle-dev-utils/printErrors.js
+++ b/packages/razzle-dev-utils/printErrors.js
@@ -12,12 +12,17 @@ function printErrors(summary, errors, verbose) {
   console.log(chalk.red(summary));
   console.log();
   errors.forEach(err => {
-    if (err.message) {
-      console.error(err.message);
-    }
-    console.error(err.stack || err);
-    if (err.details) {
-      console.error(err.details);
+    if (Array.isArray(err)) {
+      // webpack 4 format
+      console.error(err.join(''));
+    } else {
+      if (err.message) {
+        console.error(err.message);
+      }
+      console.error(err.stack || err);
+      if (err.details) {
+        console.error(err.details);
+      }
     }
     console.log();
   });

--- a/packages/razzle-dev-utils/printWarnings.js
+++ b/packages/razzle-dev-utils/printWarnings.js
@@ -12,14 +12,19 @@ function printWarnings(summary, warnings, verbose) {
   console.log(chalk.yellow(summary));
   console.log();
   warnings.forEach(wrn => {
-    if (wrn.message) {
-      console.warn(wrn.message);
-    }
-    if (verbose) {
-      console.warn(wrn.stack || wrn);
-    }
-    if (wrn.details) {
-      console.warn(wrn.details);
+    if (typeof wrn === 'string') {
+      // webpack 4
+      console.warn(wrn);
+    } else {
+      if (wrn.message) {
+        console.warn(wrn.message);
+      }
+      if (verbose) {
+        console.warn(wrn.stack || wrn);
+      }
+      if (wrn.details) {
+        console.warn(wrn.details);
+      }
     }
     console.log();
   });


### PR DESCRIPTION
Webpack 4 has a different output format for warnings and errors than webpack 5. Weirdly enough this is a string and array of strings.

Closes #1558