### PR TITLE
docs: Fix error in preset readme regarding installation

### DIFF
--- a/packages/babel-preset-razzle/README.md
+++ b/packages/babel-preset-razzle/README.md
@@ -4,7 +4,7 @@ This package includes the [Babel](https://babeljs.io) preset used by [Razzle](ht
 
 ## Usage in Razzle Projects
 
-The easiest way to use this configuration is with Razzle, which includes it by default. **You don’t need to install it separately in Razzle projects.**
+The easiest way to use this configuration is with Razzle, which includes it by default.
 
 ## Usage Outside of Razzle
 


### PR DESCRIPTION
README says it doesn't need to be installed separately when in fact it does, at least for razzle 4.0.4, which lists it as peerDependency. Razzle documentation is also saying to install it explicitely.

https://razzlejs.org/getting-started#dependencies