### PR TITLE
[WIP] Remove clean-css use CSS nano instead

### DIFF
--- a/examples/with-less/package.json
+++ b/examples/with-less/package.json
@@ -9,7 +9,7 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "resolutions": {
-    "postcss": "8.2.4"
+    "postcss": "8.2.13"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -20,7 +20,7 @@
     "babel-preset-razzle": "4.0.4",
     "less": "^4.1.0",
     "mini-css-extract-plugin": "^0.9.0",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.13",
     "razzle": "4.0.4",
     "razzle-dev-utils": "4.0.4",
     "razzle-plugin-less": "4.0.4",

--- a/examples/with-less/package.json
+++ b/examples/with-less/package.json
@@ -8,9 +8,6 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
-  "resolutions": {
-    "postcss": "8.2.13"
-  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-scss-options/package.json
+++ b/examples/with-scss-options/package.json
@@ -8,9 +8,6 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
-  "resolutions": {
-    "postcss": "8.2.13"
-  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-scss-options/package.json
+++ b/examples/with-scss-options/package.json
@@ -9,7 +9,7 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "resolutions": {
-    "postcss": "8.2.4"
+    "postcss": "8.2.13"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -24,7 +24,7 @@
     "razzle-dev-utils": "4.0.4",
     "razzle-plugin-scss": "4.0.4",
     "webpack": "^4.44.1",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.13",
     "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/with-scss/package.json
+++ b/examples/with-scss/package.json
@@ -8,9 +8,6 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
-  "resolutions": {
-    "postcss": "8.2.13"
-  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-scss/package.json
+++ b/examples/with-scss/package.json
@@ -9,7 +9,7 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "resolutions": {
-    "postcss": "8.2.4"
+    "postcss": "8.2.13"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -24,7 +24,7 @@
     "razzle-dev-utils": "4.0.4",
     "razzle-plugin-scss": "4.0.4",
     "webpack": "^4.44.1",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.13",
     "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -8,9 +8,6 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
-  "resolutions": {
-    "postcss": "8.2.13"
-  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -9,7 +9,7 @@
     "start:prod": "NODE_ENV=production node build/server.js"
   },
   "resolutions": {
-    "postcss": "8.2.4"
+    "postcss": "8.2.13"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -24,7 +24,7 @@
     "webpack": "^4.44.1",
     "babel-preset-razzle": "4.0.4",
     "webpack-dev-server": "^3.11.2",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.13",
     "autoprefixer": "^10.2.3",
     "tailwindcss": "^2.0.2"
   }

--- a/packages/razzle-plugin-less/package.json
+++ b/packages/razzle-plugin-less/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "less": "^4.1.0",
     "mini-css-extract-plugin": "^0.9.0",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.13",
     "razzle": "4.0.4",
     "razzle-dev-utils": "4.0.4",
     "style-loader": "^2.0.0",

--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -940,24 +940,6 @@ module.exports = (
               minimizerOptions: {
                 sourceMap: razzleOptions.enableSourceMaps
               },
-              minify: async (data, inputMap, minimizerOptions) => {
-                // eslint-disable-next-line global-require
-                const CleanCSS = require('clean-css');
-
-                const [[filename, input]] = Object.entries(data);
-                const minifiedCss = await new CleanCSS({ sourceMap: minimizerOptions.sourceMap }).minify({
-                  [filename]: {
-                    styles: input,
-                    sourceMap: inputMap,
-                  },
-                });
-
-                return {
-                  css: minifiedCss.styles,
-                  map: minifiedCss.sourceMap ? minifiedCss.sourceMap.toJSON() : '',
-                  warnings: minifiedCss.warnings,
-                };
-              },
             })
           ],
         }

--- a/packages/razzle/config/loadRazzleConfig.js
+++ b/packages/razzle/config/loadRazzleConfig.js
@@ -10,10 +10,6 @@ const loadPlugins = require('./loadPlugins');
 
 module.exports = (webpackObject, razzleConfig, packageJsonIn) => {
   return new Promise(async resolve => {
-    console.info("If you have issues with css make sure postcss resolves to v8.2.4.");
-    console.info("See: https://razzlejs.org/getting-started#common-problems\n");
-    console.warn("CssMinimizerPlugin currently uses clean-css,\nwe will switch to cssnano once it supports postcss v8.2.4.\n");
-
     let razzle = razzleConfig || {};
     let packageJson = packageJsonIn || {};
     let paths = Object.assign({}, defaultPaths);

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -28,7 +28,6 @@
     "babel-plugin-transform-define": "2.0.0",
     "buffer": "6.0.3",
     "chalk": "^4.1.0",
-    "clean-css": "^5.0.1",
     "copy-webpack-plugin": "6.1.1",
     "css-loader": "5.0.0",
     "css-minimizer-webpack-plugin": "^1.2.0",

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -42,7 +42,7 @@
     "mri": "^1.1.4",
     "null-loader": "4.0.1",
     "pnp-webpack-plugin": "^1.6.4",
-    "postcss": "8.2.4",
+    "postcss": "8.2.13",
     "postcss-load-config": "3.0.0",
     "postcss-loader": "4.2.0",
     "process": "0.11.10",

--- a/website/pages/getting-started.mdx
+++ b/website/pages/getting-started.mdx
@@ -109,18 +109,6 @@ Also if there are issues, try adding specific package versions to resolutions in
 
 ## Common issues
 
-If you have issues with css this might be related to postcss being resolved wrong.
-
-To fix this add:
-
-```json
-{
-  "postcss": "8.2.13"
-}
-```
-
-To resolutions in your package.json. For npm see [here](https://stackoverflow.com/questions/52416312/npm-equivalent-of-yarn-resolutions).
-
 If you get an error like this:
 
 ```

--- a/website/pages/getting-started.mdx
+++ b/website/pages/getting-started.mdx
@@ -115,9 +115,10 @@ To fix this add:
 
 ```json
 {
-  "postcss": "8.2.4"
+  "postcss": "8.2.13"
 }
 ```
+
 To resolutions in your package.json. For npm see [here](https://stackoverflow.com/questions/52416312/npm-equivalent-of-yarn-resolutions).
 
 If you get an error like this:
@@ -143,12 +144,11 @@ module.exports = {
   modifyWebpackOptions({
     options: {
       webpackOptions, // the modified options that was used to configure webpack/ webpack loaders and plugins
-    }
+    },
   }) {
-
-      webpackOptions.notNodeExternalResMatch = (request, context) => {
-         return /react-images-upload/.test(request)
-      };
+    webpackOptions.notNodeExternalResMatch = (request, context) => {
+      return /react-images-upload/.test(request);
+    };
 
     return webpackOptions;
   },
@@ -165,8 +165,8 @@ Make razzle more verbose:
 
 module.exports = {
   options: {
-    verbose: true
-  }
+    verbose: true,
+  },
 };
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,13 +4539,6 @@ clean-css@^4.2.3:
   dependencies:
     source-map "~0.6.0"
 
-clean-css@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.1.tgz#e0d168b5f5497a85f58606f009c81fdf89d84e65"
-  integrity sha512-GQ6HdEyJN0543mRTA/TkZ7RPoMXGWKq1shs9H86F2kLuixR0RI+xd4JfhJxWUW08FGKQXTKAKpVjKQXu5zkFNA==
-  dependencies:
-    source-map "~0.6.0"
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11096,6 +11096,11 @@ nanoid@^3.1.20:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
+nanoid@^3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -12719,13 +12724,13 @@ postcss@7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@8.2.4:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.4.tgz#20a98a39cf303d15129c2865a9ec37eda0031d04"
-  integrity sha512-kRFftRoExRVXZlwUuay9iC824qmXPcQQVzAjbCCgjpXnkdMCJYBu2gTwAaFBzv8ewND6O8xFb3aELmEkh9zTzg==
+postcss@8.2.13:
+  version "8.2.13"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.13.tgz#dbe043e26e3c068e45113b1ed6375d2d37e2129f"
+  integrity sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==
   dependencies:
-    colorette "^1.2.1"
-    nanoid "^3.1.20"
+    colorette "^1.2.2"
+    nanoid "^3.1.22"
     source-map "^0.6.1"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27:


### PR DESCRIPTION
PostCSS ( v8.2.10) now support Webpack 5 [See the release notes](https://github.com/postcss/postcss/releases/tag/8.2.10) &  [CSS nano release notes](https://cssnano.co/blog#major-changes-in-cssnano-5)