### PR TITLE
fix(razzle): Report config errors for start command

### DIFF
--- a/packages/razzle/scripts/build.js
+++ b/packages/razzle/scripts/build.js
@@ -1,13 +1,6 @@
 #! /usr/bin/env node
 'use strict';
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
-});
-
 const mri = require('mri');
 
 const argv = process.argv.slice(2);
@@ -35,6 +28,14 @@ const measureFileSizesBeforeBuild =
   FileSizeReporter.measureFileSizesBeforeBuild;
 const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  clearConsole();
+  logger.error('Unexpected error', err);
+  process.exit(1);
+});
 
 loadRazzleConfig(webpack).then(
   async ({ razzle, razzleOptions, webpackObject, plugins, paths }) => {

--- a/packages/razzle/scripts/export.js
+++ b/packages/razzle/scripts/export.js
@@ -3,13 +3,6 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = 'production';
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
-});
-
 const webpack = require('webpack');
 const mri = require('mri');
 const fs = require('fs-extra');
@@ -24,6 +17,15 @@ const measureFileSizesBeforeBuild =
   FileSizeReporter.measureFileSizesBeforeBuild;
 const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
 const getFileNamesAsStat = FileSizeReporter.getFileNamesAsStat;
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  clearConsole();
+  logger.error('Unexpected error', err);
+  process.exit(1);
+});
 
 const argv = process.argv.slice(2);
 const cliArgs = mri(argv);

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -29,6 +29,15 @@ process.once('SIGINT', () => {
   });
 });
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  clearConsole();
+  logger.error('Unexpected error', err);
+  process.exit(1);
+});
+
 process.noDeprecation = true; // turns off that loadQuery clutter.
 
 const argv = process.argv.slice(2);

--- a/packages/razzle/scripts/test.js
+++ b/packages/razzle/scripts/test.js
@@ -15,13 +15,6 @@ process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 
-// Makes the script crash on unhandled rejections instead of silently
-// ignoring them. In the future, promise rejections that are not handled will
-// terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
-});
-
 // Ensure environment variables are read.
 require('../config/env');
 
@@ -47,6 +40,17 @@ const createJestConfig = require('../config/createJestConfig');
 const path = require('path');
 const fs = require('fs-extra');
 const defaultPaths = require('../config/paths');
+const clearConsole = require('react-dev-utils/clearConsole');
+const logger = require('razzle-dev-utils/logger');
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  clearConsole();
+  logger.error('Unexpected error', err);
+  process.exit(1);
+});
 
 loadRazzleConfig(webpack, defaultPaths).then(
   async ({ razzle, razzleOptions, webpackObject, plugins, paths }) => {


### PR DESCRIPTION
Currently, if code inside the razzle.config.js (e.g.modifyWebpackConfig) 
throws an error, the process just quits without displaying any error message.

Long-term it might be better to catch this error a bit closer to the
code that is causing it (e.g. "modifyWebpackConfig raised an error"),
but for now this aligns the handling to what the build and test command
are already doing.