### PR TITLE
ci: Add github workflow for running prettier

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,23 @@
+name: Prettier
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+
+      - name: Install and bootstrap packages
+        run: yarn install --frozen-lockfile --ignore-engines --network-timeout 1000000
+
+      - name: Run prettier
+        run: yarn check-format

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:examples:complex": "cross-env COMPLEX=true jest --config ./test/jest.examples.config.js --verbose --no-cache -t complex",
     "clean": "lerna clean --yes",
     "format": "prettier --write 'packages/*/*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|mdx)' 'packages/*/!(node_modules)/**/*.js'",
+    "check-format": "prettier --list-different 'packages/*/*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|mdx)' 'packages/*/!(node_modules)/**/*.js'",
     "publish-all": "node ./scripts/publish-all.js",
     "publish-all-stable": "yarn publish-all -c -t --push && release && node ./scripts/release-notes.js",
     "publish-all-canary": "yarn publish-all -p canary -c -t --push && release --pre",


### PR DESCRIPTION
Prettier is configured for the repository but not all code is actually
formatted. This workflow runs also for pull requests and can ensure code
stays formatted.

---

I'm not actually familiar with github workflows, so I might be doing it not entirely correct. It does work fine on my fork though. I wasn't sure initially whether the project wants something like that, but my editor kept formatting code I didn't touch, so maybe this helps.

*Update* Oh, it even runs for this pull request now. :astonished: 