### PR TITLE
fix razzle-plugin-graphql for working with monorepo

### DIFF
--- a/packages/razzle-plugin-graphql/index.js
+++ b/packages/razzle-plugin-graphql/index.js
@@ -12,7 +12,7 @@ module.exports = {
       const graphqlLoader = {
         test: /\.(graphql|gql)$/,
         exclude: /node_modules/,
-        use: ['graphql-tag/loader']
+        use: [require.resolve('graphql-tag/loader')]
       };
 
       config.module.rules = [

--- a/packages/razzle-plugin-graphql/package.json
+++ b/packages/razzle-plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "razzle-plugin-graphql",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Use .graphql and .gql files with Razzle",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Change ```graphql-tag/loader``` to ```require.resolve('graphql-tag/loader')``` this will allow plugin to work with monorepo (lerna in my case)

Sorry for my English