### PR TITLE
with-typescript example uses StaticRouterContext

### DIFF
--- a/examples/with-typescript/src/server.tsx
+++ b/examples/with-typescript/src/server.tsx
@@ -1,7 +1,7 @@
 import express from 'express';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { StaticRouter } from 'react-router-dom';
+import { StaticRouter, StaticRouterContext } from 'react-router-dom';
 
 import App from './App';
 
@@ -27,7 +27,7 @@ const jsScriptTagsFromAssets = (assets, entrypoint, extra = '') => {
 };
 
 export const renderApp = (req: express.Request, res: express.Response) => {
-  const context: any = {};
+  const context: StaticRouterContext = {};
 
   const markup = renderToString(
     <StaticRouter context={context} location={req.url}>


### PR DESCRIPTION
React Router exports a type to be used with the `StaticRouter` context object that gets passed around instead of `any`