### PR TITLE
Follow-up fix for #1704 to remove some warnings

### DIFF
--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -851,7 +851,6 @@ module.exports = (
             disableDotRule: true,
           },
           host: dotenv.raw.HOST,
-          hot: true,
           port: devServerPort,
         };
         // If the major version is > 3, then use the newer configuration notation
@@ -881,6 +880,7 @@ module.exports = (
             disableHostCheck: true,
             clientLogLevel: 'none', // Enable gzip compression of generated files.
             publicPath: clientPublicPath,
+            hot: true,
             noInfo: true,
             overlay: false,
             quiet: true, // By default files from `contentBase` will not trigger a page reload.
@@ -928,7 +928,7 @@ module.exports = (
         config.externals = clientExternals;
 
         // Specify the client output directory and paths. Notice that we have
-        // changed the publiPath to just '/' from http://localhost:3001. This is because
+        // changed the publicPath to just '/' from http://localhost:3001. This is because
         // we will only be using one port in production.
         config.output = {
           path: paths.appBuildPublic,

--- a/packages/razzle/package.json
+++ b/packages/razzle/package.json
@@ -67,7 +67,7 @@
     "mini-css-extract-plugin": ">=0.9.0 <1.0.0",
     "razzle-dev-utils": "4.2.2",
     "webpack": "~4||~5",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0||~4"
   },
   "keywords": [
     "inferno",


### PR DESCRIPTION
- Updated `packages/razzle/package.json` to allow `webpack-dev-server` v4 as a peerDependency
- Updated `createConfigAsync.js` to move the `hot: true` flag into just the v3 config since it is on by default for v4 removing the following warning:
```
[webpack-dev-server] "hot: true" automatically applies HMR plugin, you don't have to add it manually to your webpack configuration.
```
- Also fixed a small typo in a comment