### PR TITLE
Additional follow-up fix for #1704 to remove remaining warnings

### DIFF
--- a/packages/razzle-dev-utils/devServerMajor.js
+++ b/packages/razzle-dev-utils/devServerMajor.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const devserverPkg = require('webpack-dev-server/package.json');
+
+module.exports = devserverPkg.version ? parseInt(devserverPkg.version[0]) : 3;

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -17,9 +17,6 @@ var devServerMajorVersion = require('./devServerMajor');
 var formatWebpackMessages = require('./formatWebpackMessages');
 var ErrorOverlay = require('react-error-overlay');
 
-var socketUrl = createSocketUrl();
-var parsedSocketUrl = url.parse(socketUrl);
-
 var createSocketUrl;
 if (devServerMajorVersion > 3) {
   // The path changed with v4
@@ -27,6 +24,9 @@ if (devServerMajorVersion > 3) {
 } else {
   createSocketUrl = require('webpack-dev-server/client/utils/createSocketUrl');
 }
+
+var socketUrl = createSocketUrl();
+var parsedSocketUrl = url.parse(socketUrl);
 
 ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
   // Keep this sync with errorOverlayMiddleware.js

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -27,7 +27,6 @@ if (devServerMajorVersion > 3) {
 } else {
   createSocketUrl = require('webpack-dev-server/client/utils/createSocketUrl');
 }
-console.error('hotDevClient', { devServerMajorVersion });
 
 ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
   // Keep this sync with errorOverlayMiddleware.js

--- a/packages/razzle-dev-utils/webpackHotDevClient.js
+++ b/packages/razzle-dev-utils/webpackHotDevClient.js
@@ -12,13 +12,22 @@
 var SockJS = require('sockjs-client');
 var stripAnsi = require('strip-ansi');
 var url = require('url');
-var createSocketUrl = require('webpack-dev-server/client/utils/createSocketUrl');
 var launchEditorEndpoint = require('react-dev-utils/launchEditorEndpoint');
+var devServerMajorVersion = require('./devServerMajor');
 var formatWebpackMessages = require('./formatWebpackMessages');
 var ErrorOverlay = require('react-error-overlay');
 
 var socketUrl = createSocketUrl();
 var parsedSocketUrl = url.parse(socketUrl);
+
+var createSocketUrl;
+if (devServerMajorVersion > 3) {
+  // The path changed with v4
+  createSocketUrl = require('webpack-dev-server/client/utils/createSocketURL');
+} else {
+  createSocketUrl = require('webpack-dev-server/client/utils/createSocketUrl');
+}
+console.error('hotDevClient', { devServerMajorVersion });
 
 ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
   // Keep this sync with errorOverlayMiddleware.js

--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -895,7 +895,7 @@ module.exports = (
         config.plugins = [
           ...config.plugins,
           devServerMajorVersion > 3
-            ? null // avoid warning since, webpack v4 automatically adds the HRM plugin when `hot` is true
+            ? null // avoid warning since v4 automatically adds the HRM plugin when `hot` is true
             : new webpack.HotModuleReplacementPlugin({
                 // set this true will break HtmlWebpackPlugin
                 multiStep: !clientOnly,

--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -24,10 +24,7 @@ const logger = require('razzle-dev-utils/logger');
 const razzlePaths = require('./paths');
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 const webpackMajor = require('razzle-dev-utils/webpackMajor');
-const devserverPkg = require('webpack-dev-server/package.json');
-
-// Parse the first character from the `x.y.z` version notation (i.e. major version)
-const devServerMajorVersion = parseInt(devserverPkg.version[0]);
+const devServerMajorVersion = require('razzle-dev-utils/devServerMajor');
 
 const hasPostCssConfigTest = () => {
   try {
@@ -850,6 +847,7 @@ module.exports = (
             // See https://github.com/facebookincubator/create-react-app/issues/387.
             disableDotRule: true,
           },
+          hot: true,
           host: dotenv.raw.HOST,
           port: devServerPort,
         };
@@ -880,7 +878,6 @@ module.exports = (
             disableHostCheck: true,
             clientLogLevel: 'none', // Enable gzip compression of generated files.
             publicPath: clientPublicPath,
-            hot: true,
             noInfo: true,
             overlay: false,
             quiet: true, // By default files from `contentBase` will not trigger a page reload.
@@ -897,10 +894,12 @@ module.exports = (
         // Add client-only development plugins
         config.plugins = [
           ...config.plugins,
-          new webpack.HotModuleReplacementPlugin({
-            // set this true will break HtmlWebpackPlugin
-            multiStep: !clientOnly,
-          }),
+          devServerMajorVersion > 3
+            ? null // avoid warning since, webpack v4 automatically adds the HRM plugin when `hot` is true
+            : new webpack.HotModuleReplacementPlugin({
+                // set this true will break HtmlWebpackPlugin
+                multiStep: !clientOnly,
+              }),
           shouldUseReactRefresh
             ? new ReactRefreshWebpackPlugin({
                 overlay: {

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -168,6 +168,13 @@ function main() {
               );
             }
 
+            // Provide a reusable logger function
+            const errorLogger = (err) => {
+              if (err) {
+                logger.error(err);
+              }
+            };
+
             if (!serverOnly) {
               // Create a new instance of Webpack-dev-server for our client assets.
               // This will actually run on a different port than the users app.
@@ -177,14 +184,10 @@ function main() {
               );
               if (devServerMajorVersion > 3) {
                 // listen was deprecated in v4 and causes issues when used, switch to its replacement
-                clientDevServer.start();
+                clientDevServer.startCallback(errorLogger);
               } else {
                 // Start Webpack-dev-server
-                clientDevServer.listen(port, err => {
-                  if (err) {
-                    logger.error(err);
-                  }
-                });
+                clientDevServer.listen(port, errorLogger);
               }
             }
 
@@ -193,9 +196,9 @@ function main() {
                 if (clientDevServer) {
                   if (devServerMajorVersion > 3) {
                     // close was deprecated in v4, switch to its replacement
-                    clientDevServer.stop();
+                    clientDevServer.stopCallback(errorLogger);
                   } else {
-                    clientDevServer.close();
+                    clientDevServer.close(errorLogger);
                   }
                 }
                 if (watching) {

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -179,7 +179,7 @@ function main() {
                 // listen was deprecated in v4 and causes issues when used, switch to its replacement
                 clientDevServer.start();
               } else {
-                // Start Webpack-dev-server with the explicit host and port
+                // Start Webpack-dev-server
                 clientDevServer.listen(port, err => {
                   if (err) {
                     logger.error(err);

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -176,7 +176,7 @@ function main() {
                 Object.assign(clientConfig.devServer, { verbose, port }),
               );
               if (devServerMajorVersion > 3) {
-                // listen was deprecated in v4 and causes issues when use, switch to its replacement
+                // listen was deprecated in v4 and causes issues when used, switch to its replacement
                 clientDevServer.start();
               } else {
                 // Start Webpack-dev-server with the explicit host and port

--- a/packages/razzle/scripts/start.js
+++ b/packages/razzle/scripts/start.js
@@ -173,7 +173,7 @@ function main() {
               // This will actually run on a different port than the users app.
               clientDevServer = new devServer(
                 clientCompiler,
-                Object.assign(clientConfig.devServer, { verbose: verbose, port }),
+                Object.assign(clientConfig.devServer, { verbose, port }),
               );
               if (devServerMajorVersion > 3) {
                 // listen was deprecated in v4 and causes issues when use, switch to its replacement


### PR DESCRIPTION
- Added `devServerMajor.js` to `razzle-dev-utils` that refactors the detection of the `webpack-dev-server` version in a manner similar to `webpackMajor.js`
- Updated `webpackHotDevClient.js` to use `devServerMajor.js` to pickup the properly cased `createSocketUrl`
  - Hopefully this approach won't break things like the change that was made previously that ended up getting reverted
- Updated `createConfigAsync.js` to use `razzle-dev-utils/devServerMajor` for the `webpack-dev-server` version as well as:
  - Restored `hot: true` to the common `devServer` config and instead only explicitly adding the `HMR` to the plugins for v3 to avoid the following warning:
```
[webpack-dev-server] "hot: true" automatically applies HMR plugin, you don't have to add it manually to your webpack configuration.
```
- Updated `start.js` script to include `devServerMajor.js` so that v4 will `start/stop` the client dev server rather than `listen/close` used for v3
  - Also added `port` into the copied `devServer` config to allow `start()` to work properly