### PR TITLE
Fix razzle-dev-utils to add new devServerMajor.js to files

### DIFF
--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -22,7 +22,8 @@
     "prettyNodeErrors.js",
     "resolveRequest.js",
     "webpackMajor.js",
-    "formatWebpackMessages.js"
+    "formatWebpackMessages.js",
+    "devServerMajor.js"
   ],
   "dependencies": {
     "@babel/code-frame": "^7.8.3",


### PR DESCRIPTION
- Hopefully the last change to fix #1704
- Updated `package.json` in `razzle-dev-utils` to add `devServerMajor.js` to the `files` list