### PR TITLE
Update package.json to include the repository

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-basic",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/basic"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-custom-babel-config/package.json
+++ b/examples/with-custom-babel-config/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-custom-babel-config",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-babel-config"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-custom-environment-variables/package.json
+++ b/examples/with-custom-environment-variables/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-custom-environment-variables",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-environment-variables"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-custom-webpack-config/package.json
+++ b/examples/with-custom-webpack-config/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-custom-webpack-config",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-webpack-config"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-elm/package.json
+++ b/examples/with-elm/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-elm",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-elm"
+  },
   "scripts": {
     "postinstall": "elm-package install -y",
     "start": "razzle start",

--- a/examples/with-firebase-functions/package.json
+++ b/examples/with-firebase-functions/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-firebase-functions",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-firebase-functions"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-heroku/package.json
+++ b/examples/with-heroku/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-heroku",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-heroku"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-hyperapp/package.json
+++ b/examples/with-hyperapp/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-hyperapp",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-hyperapp"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-inferno/package.json
+++ b/examples/with-inferno/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-inferno",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-inferno"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-jsxstyle/package.json
+++ b/examples/with-jsxstyle/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-jsxstyle",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-jsxstyle"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-koa/package.json
+++ b/examples/with-koa/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-koa",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-koa"
+  },
   "scripts": {
     "start": "razzle start",
     "test": "razzle test --env=jsdom",

--- a/examples/with-loadable-components/package.json
+++ b/examples/with-loadable-components/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-loadable-components",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-loadable-components"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-material-ui/package.json
+++ b/examples/with-material-ui/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-material-ui",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-material-ui"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -1,6 +1,11 @@
 {
   "name": "razzle-examples-with-mdx",
   "version": "4.2.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-mdx"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-now/package.json
+++ b/examples/with-now/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-now",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-now"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-polka/package.json
+++ b/examples/with-polka/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-polka",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-polka"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-preact/package.json
+++ b/examples/with-preact/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-preact",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-preact"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-react-native-web",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-react-native-web"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-reason-react/package.json
+++ b/examples/with-reason-react/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-reason-react",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-reason-react"
+  },
   "scripts": {
     "start": "concurrently \"npm run js-watch\" \"npm run bsb-watch\"",
     "js-watch": "razzle start",

--- a/examples/with-redux/package.json
+++ b/examples/with-redux/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-redux",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-redux"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-scss/package.json
+++ b/examples/with-scss/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-scss",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-scss"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-styled-components",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-styled-components"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-typescript",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-typescript"
+  },
   "scripts": {
     "start:tsc": "tsc -b -w --preserveWatchOutput",
     "start": "concurrently \"yarn start:tsc\" \"razzle start\"",

--- a/examples/with-vendor-bundle/package.json
+++ b/examples/with-vendor-bundle/package.json
@@ -2,6 +2,11 @@
   "name": "razzle-examples-with-vendor-bundle",
   "version": "4.2.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-vendor-bundle"
+  },
   "scripts": {
     "start": "razzle start",
     "build": "razzle build",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* razzle-examples-with-vendor-bundle
* razzle-examples-with-typescript
* razzle-examples-with-styled-components
* razzle-examples-with-scss
* razzle-examples-with-redux
* razzle-examples-with-reason-react
* razzle-examples-with-react-native-web
* razzle-examples-with-preact
* razzle-examples-with-polka
* razzle-examples-with-now
* razzle-examples-with-mdx
* razzle-examples-with-material-ui
* razzle-examples-with-loadable-components
* razzle-examples-with-koa
* razzle-examples-with-jsxstyle
* razzle-examples-with-inferno
* razzle-examples-with-hyperapp
* razzle-examples-with-heroku
* razzle-examples-with-firebase-functions
* razzle-examples-with-elm
* razzle-examples-with-custom-webpack-config
* razzle-examples-with-custom-environment-variables
* razzle-examples-with-custom-babel-config
* razzle-examples-basic