### PR TITLE
move razzle-plugin-manifest into razzle mono repo

### DIFF
--- a/packages/razzle-plugin-manifest/README.md
+++ b/packages/razzle-plugin-manifest/README.md
@@ -1,0 +1,33 @@
+# razzle-plugin-manifest
+
+This package contains a plugin for generating manifest file for splitted chunk paths with Razzle
+
+## Usage in Razzle Projects
+
+```
+npm i razzle-plugin-manifest
+```
+
+or
+
+```
+yarn add razzle-plugin-manifest
+```
+
+### Using the plugin with the default options
+
+```js
+// razzle.config.js
+
+module.exports = {
+  plugins: ['manifest'],
+};
+```
+
+A file called `chunks.json` will get generated at build time. you can import the file using `RAZZLE_CHUNKS_MANIFEST` enviroment variable.
+
+example:
+
+```js
+const chunks = require(process.env.RAZZLE_CHUNKS_MANIFEST);
+```

--- a/packages/razzle-plugin-manifest/index.js
+++ b/packages/razzle-plugin-manifest/index.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const path = require('path');
+
+module.exports = {
+  modifyWebpackConfig({
+    env: { target },
+    webpackConfig,
+    webpackObject,
+    paths,
+    options: {
+      pluginOptions = { fileName: path.join(paths.appBuild, 'chunks.json') },
+    },
+  }) {
+    if (target === 'web') {
+      webpackConfig.plugins.push(
+        // Output our JS and CSS files in a manifest file called chunks.json
+        // in the build directory.
+        // based on https://github.com/danethurber/webpack-manifest-plugin/issues/181#issuecomment-467907737
+        new WebpackManifestPlugin({
+          fileName: pluginOptions.fileName,
+          writeToFileEmit: true,
+          filter: item => item.isChunk,
+          generate: (seed, files) => {
+            const entrypoints = new Set();
+            files.forEach(file =>
+              ((file.chunk || {})._groups || []).forEach(group =>
+                entrypoints.add(group)
+              )
+            );
+            const entries = [...entrypoints];
+            const entryArrayManifest = entries.reduce((acc, entry) => {
+              const name =
+                (entry.options || {}).name ||
+                (entry.runtimeChunk || {}).name ||
+                entry.id;
+              const files = []
+                .concat(
+                  ...(entry.chunks || []).map(chunk =>
+                    chunk.files.map(
+                      path => webpackConfig.output.publicPath + path
+                    )
+                  )
+                )
+                .filter(Boolean);
+
+              const chunkIds = [].concat(
+                ...(entry.chunks || []).map(chunk => chunk.ids)
+              );
+
+              const cssFiles = files
+                .map(item => (item.indexOf('.css') !== -1 ? item : null))
+                .filter(Boolean);
+
+              const jsFiles = files
+                .map(item => (item.indexOf('.js') !== -1 ? item : null))
+                .filter(Boolean);
+
+              return name
+                ? {
+                    ...acc,
+                    [name]: {
+                      css: cssFiles,
+                      js: jsFiles,
+                      chunks: chunkIds,
+                    },
+                  }
+                : acc;
+            }, seed);
+            return entryArrayManifest;
+          },
+        })
+      );
+    }
+
+    webpackConfig.plugins.push(
+      new webpackObject.DefinePlugin({
+        'process.env': {
+          RAZZLE_CHUNKS_MANIFEST: JSON.stringify(pluginOptions.fileName),
+        },
+      })
+    );
+
+    return webpackConfig;
+  },
+};

--- a/packages/razzle-plugin-manifest/package.json
+++ b/packages/razzle-plugin-manifest/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "razzle-plugin-manifest",
+  "version": "4.2.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com:jaredpalmer/razzle.git",
+    "directory": "packages/razzle-plugin-manifest"
+  },
+  "main": "index.js",
+  "license": "MIT",
+  "author": {
+    "name": "Nima Arefi",
+    "email": "arefinima@gmail.com"
+  },
+  "peerDependencies": {
+    "razzle": "4.2.5",
+    "razzle-dev-utils": "4.2.5"
+  }
+}


### PR DESCRIPTION
### Description

This package contains a plugin for generating manifest file for splitted chunks with Razzle

exposes a new environment variable (`RAZZLE_CHUNKS_MANIFEST`) when used. 

###  Breaking Changes:
nothing :tada:
