### PR TITLE
Update package.json to include the repository

### DIFF
--- a/examples/basic-spa/package.json
+++ b/examples/basic-spa/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "serve -s build/public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/basic-spa"
+  },
   "dependencies": {
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/basic"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-custom-babel-config/package.json
+++ b/examples/with-custom-babel-config/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-babel-config"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-custom-devserver-options/package.json
+++ b/examples/with-custom-devserver-options/package.json
@@ -9,6 +9,12 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  
+"repository": {
+  "type": "git",
+  "url": "https://github.com/jaredpalmer/razzle.git",
+  "directory": "examples/with-custom-devserver-options"
+},
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-custom-environment-variables/package.json
+++ b/examples/with-custom-environment-variables/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-environment-variables"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-custom-webpack-config/package.json
+++ b/examples/with-custom-webpack-config/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/custom.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-custom-webpack-config"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-elm/package.json
+++ b/examples/with-elm/package.json
@@ -9,6 +9,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "set NODE_ENV=production&&node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-elm"
+  },
   "dependencies": {
     "elm-static-html-lib": "^0.1.0",
     "express": "^4.17.1"

--- a/examples/with-firebase-functions/package.json
+++ b/examples/with-firebase-functions/package.json
@@ -9,6 +9,11 @@
     "predeploy": "npm run build",
     "deploy": "firebase deploy"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-firebase-functions"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "firebase-admin": "^8.11.0",

--- a/examples/with-heroku/package.json
+++ b/examples/with-heroku/package.json
@@ -10,6 +10,11 @@
     "start:prod": "NODE_ENV=production node build/server.js",
     "deploy": "git push heroku master"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-heroku"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-hyperapp/package.json
+++ b/examples/with-hyperapp/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-hyperapp"
+  },
   "dependencies": {
     "@hyperapp/render": "^2.1.0",
     "express": "^4.17.1",

--- a/examples/with-inferno/package.json
+++ b/examples/with-inferno/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-inferno"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "inferno": "7.4.2",

--- a/examples/with-jest-snapshots/package.json
+++ b/examples/with-jest-snapshots/package.json
@@ -8,6 +8,11 @@
     "build": "razzle build",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-jest-snapshots"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-jsxstyle/package.json
+++ b/examples/with-jsxstyle/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-jsxstyle"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "jsxstyle": "^2.3.1",

--- a/examples/with-koa/package.json
+++ b/examples/with-koa/package.json
@@ -8,6 +8,11 @@
     "build": "razzle build",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-koa"
+  },
   "dependencies": {
     "koa": "^2.13.1",
     "koa-helmet": "^6.1.0",

--- a/examples/with-loadable-components/package.json
+++ b/examples/with-loadable-components/package.json
@@ -9,6 +9,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-loadable-components"
+  },
   "dependencies": {
     "@loadable/component": "^5.15.0",
     "@loadable/server": "^5.15.0",

--- a/examples/with-material-ui/package.json
+++ b/examples/with-material-ui/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-material-ui"
+  },
   "dependencies": {
     "@material-ui/core": "^4.9.11",
     "express": "^4.17.1",

--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -7,6 +7,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-mdx"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-now/package.json
+++ b/examples/with-now/package.json
@@ -9,6 +9,11 @@
     "start:prod": "NODE_ENV=production node build/server.js",
     "now-start": "yarn start:prod"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-now"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-polka/package.json
+++ b/examples/with-polka/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-polka"
+  },
   "dependencies": {
     "polka": "^0.5.2",
     "react": "^17.0.1",

--- a/examples/with-preact/package.json
+++ b/examples/with-preact/package.json
@@ -14,6 +14,11 @@
     "preact-render-to-string": "^5.1.6",
     "react": "^17.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-preact"
+  },
   "devDependencies": {
     "@prefresh/babel-plugin": "^0.2.0",
     "@prefresh/webpack": "^2.0.0",

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-react-native-web"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-reason-react/package.json
+++ b/examples/with-reason-react/package.json
@@ -11,6 +11,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-reason-react"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-redux/package.json
+++ b/examples/with-redux/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-redux"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "prop-types": "^15.7.2",

--- a/examples/with-scss/package.json
+++ b/examples/with-scss/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-scss"
+  },
   "resolutions": {
     "postcss": "8.2.4"
   },

--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-styled-components"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-typescript-plugin/package.json
+++ b/examples/with-typescript-plugin/package.json
@@ -14,6 +14,11 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-typescript-plugin"
+  },
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/jest": "^26.0.20",

--- a/examples/with-vendor-bundle/package.json
+++ b/examples/with-vendor-bundle/package.json
@@ -8,6 +8,11 @@
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-vendor-bundle"
+  },
   "dependencies": {
     "express": "^4.17.1",
     "react": "^17.0.1",

--- a/examples/with-webpack-public-path/package.json
+++ b/examples/with-webpack-public-path/package.json
@@ -13,6 +13,11 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredpalmer/razzle.git",
+    "directory": "examples/with-webpack-public-path"
+  },
   "devDependencies": {
     "razzle": "4.2.6",
     "razzle-dev-utils": "4.2.6",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* razzle-examples-basic
* razzle-examples-basic-spa
* razzle-examples-with-custom-babel-config
* razzle-examples-with-custom-devserver-options
* razzle-examples-with-custom-environment-variables
* razzle-examples-with-custom-webpack-config
* razzle-examples-with-elm
* razzle-examples-with-typescript
* razzle-examples-with-firebase-functions
* razzle-examples-with-heroku
* razzle-examples-with-hyperapp
* razzle-examples-with-inferno
* razzle-examples-with-jest
* razzle-examples-with-jsxstyle
* razzle-examples-with-koa
* razzle-examples-with-loadable-components
* razzle-examples-with-material-ui
* razzle-examples-with-mdx
* razzle-examples-with-now
* razzle-examples-with-polka
* razzle-examples-with-preact
* razzle-examples-with-react-native-web
* razzle-examples-with-reason-react
* razzle-examples-with-redux
* razzle-examples-with-scss
* razzle-examples-with-styled-components
* razzle-examples-with-vendor-bundle
* razzle-examples-basic