### PR TITLE
Do not wrap build errors in array before printing

### DIFF
--- a/packages/razzle/scripts/build.js
+++ b/packages/razzle/scripts/build.js
@@ -186,7 +186,7 @@ loadRazzleConfig(webpack).then(
                     err => {
                       printErrors(
                         `Failed to compile client ${buildName} build.`,
-                        [err],
+                        Array.isArray(err) ? err : [err],
                         verbose
                       );
                       rejectBuild(buildName, 'web');
@@ -285,7 +285,7 @@ loadRazzleConfig(webpack).then(
                   err => {
                     printErrors(
                       `Failed to compile server ${buildName} build.`,
-                      [err],
+                      Array.isArray(err) ? err : [err],
                       verbose
                     );
                     rejectBuild(buildName, 'node');


### PR DESCRIPTION
This applies to the `build.js` script that's executed on `yarn build`

## How it currently works
When build errors occurs (or warnings for CI builds) the build promise is rejected with an array – the error messages, see https://github.com/jaredpalmer/razzle/blob/v4.2.6/packages/razzle/scripts/build.js#L112-L114 for an example.

When handling the rejected promise, the error is wrapped in an array before calling `printErrors` as it's expects an array of errors to print. This is fine when the promise is rejected with an actual `Error` but for build errors this means that the array gets wrapped in a new array, and instead of getting an array of _n_  messages, `printErrors` receives an array with 1 element and it will log the array instead of the indivdual messages, see #1753 for an example on what this looks like.

## This PR
There is no need to wrap the array of error messages in a new array before calling printErrors, so in the catch clause if   `err` is an array, it will not be wrapped. If it's not an array, it's wrapped, just like previously.

## Verification
I've manually verified this PR with webpack 4 for `examples/basic` and webpack 5 for `examples/with-preact`. Syntax errors where introduced to the examples with this:

``` sh
echo 'just some text' >> examples/basic/src/App.js
echo 'just some text' >> examples/with-preact/src/App.js
```

And then `yarn build --noninteractive` was ran for each example.

Of course `yarn test --runInBand` was ran as well.

Fixes #1753