### PR TITLE
fix: process.env won't be overwritten by razzle-plugin-manifest

### DIFF
--- a/packages/razzle-plugin-manifest/index.js
+++ b/packages/razzle-plugin-manifest/index.js
@@ -76,9 +76,7 @@ module.exports = {
 
     webpackConfig.plugins.push(
       new webpackObject.DefinePlugin({
-        'process.env': {
-          RAZZLE_CHUNKS_MANIFEST: JSON.stringify(pluginOptions.fileName),
-        },
+        'process.env.RAZZLE_CHUNKS_MANIFEST': JSON.stringify(pluginOptions.fileName),
       })
     );
 


### PR DESCRIPTION
This fixes an issue where the razzle-plugin-manifest was replacing the entire process.env with a new object with only one property `RAZZLE_CHUNKS_MANIFEST`.