### PR TITLE
add support for type:module razzle.config.js

### DIFF
--- a/packages/razzle/config/loadRazzleConfig.js
+++ b/packages/razzle/config/loadRazzleConfig.js
@@ -8,10 +8,11 @@ const defaultRazzleOptions = require('./defaultOptions');
 const setupEnvironment = require('./env').setupEnvironment;
 const loadPlugins = require('./loadPlugins');
 
-const getTypeModule = appPackageJson => {
+const getModuleFormat = appPackageJson => {
   if (fs.existsSync(appPackageJson)) {
     try {
       const packageJson = require(appPackageJson);
+      // See https://nodejs.org/api/packages.html#type for more info on "type"
       return packageJson.type || "commonjs";
     } catch (e) {
       clearConsole();
@@ -31,7 +32,7 @@ module.exports = (webpackObject, razzleConfig, packageJsonIn) => {
     // Check for razzle.config.js file
     if (fs.existsSync(paths.appRazzleConfig)) {
       try {
-        if (getTypeModule(paths.appPackageJson) === 'module') {
+        if (getModuleFormat(paths.appPackageJson) === 'module') {
           razzle = await import(paths.appRazzleConfig);
         }
         else {


### PR DESCRIPTION
Uses `package.json`'s `type` field to determine whether to `require()` or `await import()`

The `package.json` detection is modelled on `getPublicUrl` in `razzle/packages/razzle/config/paths.js` and doesn't implement the full spec described by https://nodejs.org/api/packages.html#type ("The nearest parent package.json is defined as the first package.json found when searching in the current folder, that folder’s parent, and so on up until a node_modules folder or the volume root is reached.")