### PR TITLE
Remove the require of `jest` and `chalk` as they are not used in the file

### DIFF
--- a/packages/razzle/config/createJestConfig.js
+++ b/packages/razzle/config/createJestConfig.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const chalk = require('chalk');
-const jest = require('jest');
 const clearConsole = require('react-dev-utils/clearConsole');
 const logger = require('razzle-dev-utils/logger');
 


### PR DESCRIPTION
- The require of `jest` is preventing the use of `createJestConfig()` in our testing of a razzle plugin
- Since there were two unused `require` of libraries, removed them both