### PR TITLE
fix(razzle) Add "dot" option to CopyPlugin to copy hidden files

### DIFF
--- a/packages/razzle/config/createConfigAsync.js
+++ b/packages/razzle/config/createConfigAsync.js
@@ -962,6 +962,7 @@ module.exports = (
                 context: paths.appPath,
                 globOptions: {
                   ignore: [paths.appPublic.replace(/\\/g, '/') + "/index.html"],
+                  dot: true,
                 }
               },
             ]


### PR DESCRIPTION
Adds dot config option to copy-webpack-plugin so that hidden files are also copied from public folder to the build folder.

This was the behaviour already in Razzle 3.

Closes https://github.com/jaredpalmer/razzle/issues/1874 