### PR TITLE
fix(vercel-example): remove deprecated use from vercel deployment example

### DIFF
--- a/website/pages/deployment-options/vercel.md
+++ b/website/pages/deployment-options/vercel.md
@@ -9,11 +9,11 @@ Create this vercel.json in the root directory of your project:
     "builds": [
         {
             "src": "build/public/**",
-            "use": "@now/static"
+            "use": "@vercel/static"
         },
         {
             "src": "build/server.js",
-            "use": "@now/node-server"
+            "use": "@vercel/node"
         }
     ],
     "routes": [


### PR DESCRIPTION
the packages `@now/static` and `@now/node` are now deprecated. Instead, it is now recommended to use `@vercel/static` and `@vercel/node` respectively

Using the old example, you get an error similar to this on Vercel when trying to deploy:

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/8383781/179980925-7bf63850-31f5-423d-acbe-1afcc4b11c0b.png">
