### PR TITLE
Fix dev server

### DIFF
--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -33,7 +33,7 @@
     "gzip-size": "^6.0.0",
     "jest-message-util": "^26.3.0",
     "react-dev-utils": "^11.0.4",
-    "react-error-overlay": "^6.0.11",
+    "react-error-overlay": "^6.0.9",
     "recursive-readdir": "^2.2.2",
     "resolve": "^1.17.0",
     "sockjs-client": "~1.4.0",

--- a/packages/razzle-dev-utils/package.json
+++ b/packages/razzle-dev-utils/package.json
@@ -33,7 +33,7 @@
     "gzip-size": "^6.0.0",
     "jest-message-util": "^26.3.0",
     "react-dev-utils": "^11.0.4",
-    "react-error-overlay": "^6.0.7",
+    "react-error-overlay": "^6.0.11",
     "recursive-readdir": "^2.2.2",
     "resolve": "^1.17.0",
     "sockjs-client": "~1.4.0",


### PR DESCRIPTION
I'm having [this issue](https://github.com/facebook/create-react-app/issues/11880) during local development with `razzle-dev-utils@4.2.17`. I can fix it locally using [this hack](https://github.com/facebook/create-react-app/issues/11880#issuecomment-1144976471), but it would be better not to have to override Razzle's dependencies :) 